### PR TITLE
Fix syntax highlighting.

### DIFF
--- a/src/view/buffer_renderer.rs
+++ b/src/view/buffer_renderer.rs
@@ -159,11 +159,7 @@ impl<'a, 'b> BufferRenderer<'a, 'b> {
     // Uses the lexeme's scopes to update the current
     // style, so that print calls will use the right color.
     fn update_current_style(&mut self, lexeme: &Lexeme) {
-        self.current_style = self.current_style.apply(
-            self.stylist.get_style(
-                lexeme.scope.as_slice()
-            )
-        );
+        self.current_style = self.stylist.style_for_stack(lexeme.scope.as_slice())
     }
 
     pub fn print_lexeme(&mut self, lexeme: Lexeme) {


### PR DESCRIPTION
This is a fairly naive attempt to solve #22. It forces a style recomputation for every `Lexeme`.

The current method is trying to just apply it based on the most recent style in the stack. But from my understanding this basically won't apply any changes if `scope[..len-1]` -> `scope` doesn't require any style changes. Which is frequently the case.
Basically, `get_style` doesn't seem to be the right thing to use. See [comment](https://docs.rs/syntect/1.7.1/src/syntect/highlighting/highlighter.rs.html#190):
> I have a good argument nobody will ever need to use the method.

`style_for_stack` instead just recomputes the style for whatever given scope you are looking at, but the method says:
 > This operation is convenient but expensive. For reasonable performance, the caller should be caching results.

So there may be better options. E.g., doing something like `HighlightIterator` ([source](https://docs.rs/syntect/1.7.1/src/syntect/highlighting/highlighter.rs.html#103)). But that seems to require larger changes further down the stack, i.e. in scribe.