### PR TITLE
Specify required python version

### DIFF
--- a/documentation/pages/installation.md
+++ b/documentation/pages/installation.md
@@ -38,7 +38,7 @@ brew tap jmacdonald/amp && brew install amp
 ### Build Dependencies
 
 * `cmake`
-* `python`
+* `python3`
 * `rust`
 
 ### Building


### PR DESCRIPTION
XCB specifically requires python3, and the error in the version amp depends on is _very_ unhelpful, https://github.com/rtbo/rust-xcb/issues/49

I ran into this last night when I helped a friend install amp and it did not build on their machine despite having python, later I tracked down this issue and noticed that the python file in the XCB repo specifies python3.