### PR TITLE
Added support for configuring the search_select pane

### DIFF
--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -96,14 +96,16 @@ pub fn switch_to_line_jump_mode(app: &mut Application) -> Result {
 
 pub fn switch_to_open_mode(app: &mut Application) -> Result {
     let exclusions = app.preferences.borrow().open_mode_exclusions()?;
-    app.mode = Mode::Open(OpenMode::new(app.workspace.path.clone(), exclusions, app.event_channel.clone()));
+    let config = app.preferences.borrow().search_select_config();
+    app.mode = Mode::Open(OpenMode::new(app.workspace.path.clone(), exclusions, app.event_channel.clone(), config));
     commands::search_select::search(app)?;
 
     Ok(())
 }
 
 pub fn switch_to_command_mode(app: &mut Application) -> Result {
-    app.mode = Mode::Command(CommandMode::new());
+    let config = app.preferences.borrow().search_select_config();
+    app.mode = Mode::Command(CommandMode::new(config));
     commands::search_select::search(app)?;
 
     Ok(())
@@ -113,8 +115,9 @@ pub fn switch_to_symbol_jump_mode(app: &mut Application) -> Result {
     if let Some(buf) = app.workspace.current_buffer() {
         let token_set = buf.tokens()
             .chain_err(|| "No tokens available for the current buffer")?;
+        let config = app.preferences.borrow().search_select_config();
 
-        app.mode = Mode::SymbolJump(SymbolJumpMode::new(token_set));
+        app.mode = Mode::SymbolJump(SymbolJumpMode::new(token_set, config));
     } else {
         bail!(BUFFER_MISSING);
     }
@@ -124,10 +127,12 @@ pub fn switch_to_symbol_jump_mode(app: &mut Application) -> Result {
 }
 
 pub fn switch_to_theme_mode(app: &mut Application) -> Result {
+    let config = app.preferences.borrow().search_select_config();
     app.mode = Mode::Theme(
         ThemeMode::new(
-            app.view.theme_set.themes.keys().map(|k| k.to_string()).collect()
-        )
+            app.view.theme_set.themes.keys().map(|k| k.to_string()).collect(),
+            config
+        ),
     );
     commands::search_select::search(app)?;
 

--- a/src/models/application/modes/command/mod.rs
+++ b/src/models/application/modes/command/mod.rs
@@ -5,7 +5,7 @@ use util::SelectableVec;
 use std::collections::HashMap;
 use std::fmt;
 use std::slice::Iter;
-use models::application::modes::{SearchSelectMode, MAX_SEARCH_SELECT_RESULTS};
+use models::application::modes::{SearchSelectMode, SearchSelectConfig};
 use commands::{self, Command};
 pub use self::displayable_command::DisplayableCommand;
 
@@ -14,15 +14,17 @@ pub struct CommandMode {
     input: String,
     commands: HashMap<&'static str, Command>,
     results: SelectableVec<DisplayableCommand>,
+    config: SearchSelectConfig,
 }
 
 impl CommandMode {
-    pub fn new() -> CommandMode {
+    pub fn new(config: SearchSelectConfig) -> CommandMode {
         CommandMode {
             insert: true,
             input: String::new(),
             commands: commands::hash_map(),
             results: SelectableVec::new(Vec::new()),
+            config,
         }
     }
 }
@@ -41,7 +43,7 @@ impl SearchSelectMode<DisplayableCommand> for CommandMode {
         let results = fragment::matching::find(
             &self.input,
             &commands,
-            MAX_SEARCH_SELECT_RESULTS
+            self.config.max_results
         );
 
         // We don't care about the result objects; we just want
@@ -91,5 +93,9 @@ impl SearchSelectMode<DisplayableCommand> for CommandMode {
 
     fn select_next(&mut self) {
         self.results.select_next();
+    }
+
+    fn config(&self) -> &SearchSelectConfig {
+        &self.config
     }
 }

--- a/src/models/application/modes/mod.rs
+++ b/src/models/application/modes/mod.rs
@@ -18,10 +18,8 @@ pub use self::line_jump::LineJumpMode;
 pub use self::path::PathMode;
 pub use self::open::OpenMode;
 pub use self::search::SearchMode;
-pub use self::search_select::SearchSelectMode;
+pub use self::search_select::{SearchSelectMode, SearchSelectConfig};
 pub use self::select::SelectMode;
 pub use self::select_line::SelectLineMode;
 pub use self::symbol_jump::SymbolJumpMode;
 pub use self::theme::ThemeMode;
-
-pub const MAX_SEARCH_SELECT_RESULTS: usize = 5;

--- a/src/models/application/modes/search_select.rs
+++ b/src/models/application/modes/search_select.rs
@@ -65,12 +65,14 @@ pub trait SearchSelectMode<T: Display>: Display {
 mod tests {
     use std::fmt;
     use std::slice::Iter;
-    use super::SearchSelectMode;
+    use super::{SearchSelectMode, SearchSelectConfig};
 
+    #[derive(Default)]
     struct TestMode {
         input: String,
         selection: String,
         results: Vec<String>,
+        config: SearchSelectConfig,
     }
 
     impl fmt::Display for TestMode {
@@ -92,32 +94,33 @@ mod tests {
         fn selected_index(&self) -> usize { 0 }
         fn select_previous(&mut self) { }
         fn select_next(&mut self) { }
+        fn config(&self) -> &SearchSelectConfig { &self.config }
     }
 
     #[test]
     fn push_search_char_updates_query() {
-        let mut mode = TestMode{ input: String::new(), selection: String::new(), results: Vec::new() };
+        let mut mode = TestMode{ .. Default::default() };
         mode.push_search_char('a');
         assert_eq!(mode.query(), "a");
     }
 
     #[test]
     fn pop_search_token_pops_all_characters_when_on_only_token() {
-        let mut mode = TestMode{ input: String::from("amp"), selection: String::new(), results: Vec::new() };
+        let mut mode = TestMode{ input: String::from("amp"), .. Default::default() };
         mode.pop_search_token();
         assert_eq!(mode.query(), "");
     }
 
     #[test]
     fn pop_search_token_pops_all_adjacent_non_whitespace_characters_when_on_non_whitespace_character() {
-        let mut mode = TestMode{ input: String::from("amp editor"), selection: String::new(), results: Vec::new() };
+        let mut mode = TestMode{ input: String::from("amp editor"), .. Default::default() };
         mode.pop_search_token();
         assert_eq!(mode.query(), "amp ");
     }
 
     #[test]
     fn pop_search_token_pops_all_whitespace_characters_when_on_whitespace_character() {
-        let mut mode = TestMode{ input: String::from("amp  "), selection: String::new(), results: Vec::new() };
+        let mut mode = TestMode{ input: String::from("amp  "), .. Default::default() };
         mode.pop_search_token();
         assert_eq!(mode.query(), "amp");
     }

--- a/src/models/application/modes/search_select.rs
+++ b/src/models/application/modes/search_select.rs
@@ -1,6 +1,19 @@
 use std::fmt::Display;
 use std::slice::Iter;
 
+#[derive(Clone)]
+pub struct SearchSelectConfig {
+    pub max_results: usize,
+}
+
+impl Default for SearchSelectConfig {
+    fn default() -> SearchSelectConfig {
+        SearchSelectConfig {
+            max_results: 5,
+        }
+    }
+}
+
 /// This trait will become vastly simpler if/when fields are added to traits.
 /// See: https://github.com/rust-lang/rfcs/pull/1546
 pub trait SearchSelectMode<T: Display>: Display {
@@ -13,6 +26,7 @@ pub trait SearchSelectMode<T: Display>: Display {
     fn selected_index(&self) -> usize;
     fn select_previous(&mut self);
     fn select_next(&mut self);
+    fn config(&self) -> &SearchSelectConfig;
     fn message(&mut self) -> Option<String> {
         if self.query().is_empty() {
             Some(String::from("Enter a search query to start."))

--- a/src/models/application/modes/symbol_jump.rs
+++ b/src/models/application/modes/symbol_jump.rs
@@ -8,13 +8,14 @@ use std::iter::Iterator;
 use std::clone::Clone;
 use std::str::FromStr;
 use std::slice::Iter;
-use models::application::modes::{SearchSelectMode, MAX_SEARCH_SELECT_RESULTS};
+use models::application::modes::{SearchSelectMode, SearchSelectConfig};
 
 pub struct SymbolJumpMode {
     insert: bool,
     input: String,
     symbols: Vec<Symbol>,
     results: SelectableVec<Symbol>,
+    config: SearchSelectConfig,
 }
 
 #[derive(PartialEq, Debug)]
@@ -47,7 +48,7 @@ impl AsStr for Symbol {
 }
 
 impl SymbolJumpMode {
-    pub fn new(tokens: TokenSet) -> SymbolJumpMode {
+    pub fn new(tokens: TokenSet, config: SearchSelectConfig) -> SymbolJumpMode {
         let symbols = symbols(tokens.iter());
 
         SymbolJumpMode {
@@ -55,6 +56,7 @@ impl SymbolJumpMode {
             input: String::new(),
             symbols: symbols,
             results: SelectableVec::new(Vec::new()),
+            config,
         }
     }
 }
@@ -68,7 +70,7 @@ impl fmt::Display for SymbolJumpMode {
 impl SearchSelectMode<Symbol> for SymbolJumpMode {
     fn search(&mut self) {
         // Find the symbols we're looking for using the query.
-        let results = fragment::matching::find(&self.input, &self.symbols, MAX_SEARCH_SELECT_RESULTS);
+        let results = fragment::matching::find(&self.input, &self.symbols, self.config.max_results);
 
         // We don't care about the result objects; we just want
         // the underlying symbols. Map the collection to get these.
@@ -105,6 +107,10 @@ impl SearchSelectMode<Symbol> for SymbolJumpMode {
 
     fn select_next(&mut self) {
         self.results.select_next();
+    }
+
+    fn config(&self) -> &SearchSelectConfig {
+        &self.config
     }
 }
 

--- a/src/models/application/modes/theme.rs
+++ b/src/models/application/modes/theme.rs
@@ -2,22 +2,24 @@ use fragment;
 use util::SelectableVec;
 use std::fmt;
 use std::slice::Iter;
-use models::application::modes::{SearchSelectMode, MAX_SEARCH_SELECT_RESULTS};
+use models::application::modes::{SearchSelectMode, SearchSelectConfig};
 
 pub struct ThemeMode {
     insert: bool,
     input: String,
     themes: Vec<String>,
     results: SelectableVec<String>,
+    config: SearchSelectConfig,
 }
 
 impl ThemeMode {
-    pub fn new(themes: Vec<String>) -> ThemeMode {
+    pub fn new(themes: Vec<String>, config: SearchSelectConfig) -> ThemeMode {
         ThemeMode {
             insert: true,
             input: String::new(),
             themes: themes,
             results: SelectableVec::new(Vec::new()),
+            config,
         }
     }
 }
@@ -31,7 +33,7 @@ impl fmt::Display for ThemeMode {
 impl SearchSelectMode<String> for ThemeMode {
     fn search(&mut self) {
         // Find the themes we're looking for using the query.
-        let results = fragment::matching::find(&self.input, &self.themes, MAX_SEARCH_SELECT_RESULTS);
+        let results = fragment::matching::find(&self.input, &self.themes, self.config.max_results);
 
         // We don't care about the result objects; we just want
         // the underlying symbols. Map the collection to get these.
@@ -73,5 +75,9 @@ impl SearchSelectMode<String> for ThemeMode {
 
     fn select_next(&mut self) {
         self.results.select_next();
+    }
+
+    fn config(&self) -> &SearchSelectConfig {
+        &self.config
     }
 }

--- a/src/models/application/preferences.rs
+++ b/src/models/application/preferences.rs
@@ -8,6 +8,7 @@ use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::PathBuf;
 use yaml::yaml::{Hash, Yaml, YamlLoader};
+use models::application::modes::SearchSelectConfig;
 
 const FILE_NAME: &'static str = "config.yml";
 const APP_INFO: AppInfo = AppInfo {
@@ -22,6 +23,7 @@ const TAB_WIDTH_KEY: &'static str = "tab_width";
 const LINE_LENGTH_GUIDE_KEY: &'static str = "line_length_guide";
 const LINE_WRAPPING_KEY: &'static str = "line_wrapping";
 const SOFT_TABS_KEY: &'static str = "soft_tabs";
+const SEARCH_SELECT_KEY: &'static str = "search_select";
 
 const THEME_DEFAULT: &'static str = "solarized_dark";
 const TAB_WIDTH_DEFAULT: usize = 2;
@@ -153,6 +155,16 @@ impl Preferences {
                 None
             })
             .unwrap_or(TAB_WIDTH_DEFAULT)
+    }
+
+    pub fn search_select_config(&self) -> SearchSelectConfig {
+        let mut result = SearchSelectConfig::default();
+        if let Some(ref data) = self.data {
+            if let Yaml::Integer(max_results) = data[SEARCH_SELECT_KEY]["max_results"] {
+                result.max_results = max_results as usize;
+            }
+        }
+        result
     }
 
     pub fn soft_tabs(&self, path: Option<&PathBuf>) -> bool {

--- a/src/presenters/modes/search_select.rs
+++ b/src/presenters/modes/search_select.rs
@@ -1,7 +1,7 @@
 use errors::*;
 use std::cmp;
 use std::fmt::Display;
-use models::application::modes::{SearchSelectMode, MAX_SEARCH_SELECT_RESULTS};
+use models::application::modes::{SearchSelectMode};
 use pad::PadStr;
 use presenters::current_buffer_status_line_data;
 use scribe::Workspace;
@@ -10,6 +10,8 @@ use view::{Colors, StatusLineData, Style, View};
 use unicode_segmentation::UnicodeSegmentation;
 
 pub fn display<T: Display>(workspace: &mut Workspace, mode: &mut SearchSelectMode<T>, view: &mut View) -> Result<()> {
+    let mode_config = mode.config().clone();
+
     // Wipe the slate clean.
     view.clear();
 
@@ -51,7 +53,7 @@ pub fn display<T: Display>(workspace: &mut Workspace, mode: &mut SearchSelectMod
     }
 
     // Clear any remaining lines in the result display area.
-    for line in cmp::max(mode.results().len(), 1)..5 {
+    for line in cmp::max(mode.results().len(), 1)..mode_config.max_results {
         view.print(&Position{ line: line, offset: 0 },
                    Style::Default,
                    Colors::Default,
@@ -59,7 +61,7 @@ pub fn display<T: Display>(workspace: &mut Workspace, mode: &mut SearchSelectMod
     }
 
     // Draw the divider.
-    let line = MAX_SEARCH_SELECT_RESULTS;
+    let line = mode_config.max_results;
     let colors = if mode.insert_mode() {
         Colors::Insert
     } else {
@@ -73,7 +75,7 @@ pub fn display<T: Display>(workspace: &mut Workspace, mode: &mut SearchSelectMod
 
     // Place the cursor on the search input line, right after its contents.
     view.set_cursor(Some(Position {
-        line: MAX_SEARCH_SELECT_RESULTS,
+        line: mode_config.max_results,
         offset: mode.query().graphemes(true).count(),
     }));
 


### PR DESCRIPTION
This adds a new entry in the yaml config that allows you to set the height of the search_select window.

    search_select:
      max_results: 30

This changes what used to be ```MAX_SEARCH_SELECT_RESULTS```, and I also found a bug where a hard-code 5 was used.

I only added this one option, but because of the amount of changes it required, I decided to add it as a struct so future options can be added more easily in the future.