### PR TITLE
Generated files should go into OUT_DIR and not the working directory

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,8 +18,10 @@ fn main() {
 fn generate_commands() {
     // Create the output file and write the opening lines.
     let current_dir = env::current_dir().expect("Couldn't get the current directory");
-    let mut output = File::create("src/commands/hash_map")
-        .expect("Couldn't create output file");
+    let out_dir = env::var("OUT_DIR").expect("The compiler did not provide $OUT_DIR");
+    let out_file: std::path::PathBuf = [&out_dir, "hash_map"].iter().collect();
+    let mut output = File::create(&out_file)
+        .expect(&format!("Couldn't create output file: {}", out_file.to_string_lossy()));
     output
         .write("{\n    let mut commands: HashMap<&'static str, Command> = HashMap::new();\n"
                    .as_bytes())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,6 @@ pub type Command = fn(&mut Application) -> Result;
 pub type Result = errors::Result<()>;
 
 pub fn hash_map() -> HashMap<&'static str, Command> {
-    include!("hash_map")
+    include!(concat!(env!("OUT_DIR"), "/hash_map"))
 }
 

--- a/src/commands/path.rs
+++ b/src/commands/path.rs
@@ -56,7 +56,7 @@ mod tests {
     use models::Application;
     use models::application::Mode;
     use scribe::Buffer;
-    use std::path::PathBuf;
+    use std::path::{PathBuf, Path};
 
     #[test]
     fn accept_path_sets_buffer_path_based_on_input_and_switches_to_normal_mode() {
@@ -93,7 +93,7 @@ mod tests {
         // Switch to the mode, add a name, set the flag, and accept it.
         commands::application::switch_to_path_mode(&mut app).unwrap();
         if let Mode::Path(ref mut mode) = app.mode {
-            mode.input = String::from("new_path");
+            mode.input = Path::new(concat!(env!("OUT_DIR"), "new_path")).to_string_lossy().into();
             mode.save_on_accept = true;
         }
         super::accept_path(&mut app).unwrap();


### PR DESCRIPTION
Generated files should no longer go into the src directory. Instead OUT_DIR should be used.

This is as currently documented: https://doc.rust-lang.org/cargo/reference/build-scripts.html#case-study-code-generation
> In general, build scripts should not modify any files outside of OUT_DIR. It may seem fine on the first blush, but it does cause problems when you use such crate as a dependency, because there's an implicit invariant that sources in .cargo/registry should be immutable. cargo won't allow such scripts when packaging.

There is even a feature in cargo to block added in https://github.com/rust-lang/cargo/pull/5584