### PR TITLE
added a mechanism for showing folders if search results are too many

### DIFF
--- a/src/models/application/modes/open/folder_filter.rs
+++ b/src/models/application/modes/open/folder_filter.rs
@@ -1,0 +1,75 @@
+use std::collections::BTreeMap;
+use std::path::{PathBuf,Path};
+
+//Limit find the longest common path
+pub fn search_as_folders<'a,IT>(it:IT)->Option<Vec<PathBuf>>
+    where IT:IntoIterator<Item=&'a Path>
+{
+    let mut it = it.into_iter();
+    let mut common = PathBuf::from(it.next()?);
+    let mut deeper = BTreeMap::new();
+    
+    deeper.insert(common.clone(),());
+
+
+    for v in it {
+        let mut v = PathBuf::from(v);
+        while ! &v.starts_with(&common) {
+            common = (common.parent()?).into();
+        }
+        if v == common {
+            continue
+        }
+        while v.parent() != Some(&common){
+            v = (v.parent()?).into();
+        }
+        deeper.insert(v,());
+    }
+
+    let mut d2 = BTreeMap::new();
+    for (mut item,_) in deeper{
+        while item.parent() != Some(&common){
+            item = (item.parent()?).into();
+        }
+        d2.insert(item,());
+    }
+    Some(d2.into_iter().map(|(k,_)|k).collect())
+}
+
+#[cfg(test)]
+mod test{
+    use super::*;
+    #[test]
+    fn folder_filter_test1(){
+        let vals = vec![
+            PathBuf::from("/hello/world/buddy"),
+            PathBuf::from("/hello/venus/buddy"),
+            PathBuf::from("/hello/buddy"),
+        ];
+        let v2:Vec<&Path> = (&vals).into_iter().map(|x|x as &Path).collect();
+        let r = search_as_folders(v2).unwrap(); 
+        assert_eq!(r,vec![
+                  PathBuf::from("/hello/buddy"),
+                  PathBuf::from("/hello/venus"),
+                  PathBuf::from("/hello/world"),
+                  ]);
+    }        
+
+    #[test]
+    fn folder_filter_test2(){
+        let vals = vec![
+            PathBuf::from("/hello/world/buddy"),
+            PathBuf::from("/hello/venus/buddy"),
+            PathBuf::from("/hello/buddy"),
+            PathBuf::from("/group/buddy"),
+        ];
+        let v2:Vec<&Path> = (&vals).into_iter().map(|x|x as &Path).collect();
+        let r = search_as_folders(v2).unwrap(); 
+        assert_eq!(r,vec![
+                  PathBuf::from("/group"),
+                  PathBuf::from("/hello"),
+                  ]);
+    }        
+
+
+}

--- a/src/models/application/modes/open/folder_filter.rs
+++ b/src/models/application/modes/open/folder_filter.rs
@@ -1,22 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::{PathBuf,Path};
 
-fn no_dot(p:&Path)->&Path{
-    if p.ends_with("..."){
-        return p.parent().expect("Ends with ..., must have parent");
-    }
-    p
-}
-fn parent_dot(mut p:&Path)->Option<PathBuf>{
-    p = no_dot(p);
-    p = p.parent()?;
-    let mut res = PathBuf::from(p);
-    res.push("...");
-    Some(res)
-}
-
-
-
 //Limit find the longest common path
 pub fn search_as_folders<'a,IT>(it:IT)->Option<Vec<PathBuf>>
     where IT:IntoIterator<Item=&'a Path>
@@ -25,25 +9,27 @@ pub fn search_as_folders<'a,IT>(it:IT)->Option<Vec<PathBuf>>
     let mut common = PathBuf::from(it.next()?);
     let mut deeper = BTreeMap::new();
     
-    
     deeper.insert(common.clone(),());
 
 
     for v in it {
         let mut v = PathBuf::from(v);
         while ! &v.starts_with(&common) {
-            common = (&common).parent()?.into();
+            common = (common.parent()?).into();
         }
         if v == common {
             continue
+        }
+        while v.parent() != Some(&common){
+            v = (v.parent()?).into();
         }
         deeper.insert(v,());
     }
 
     let mut d2 = BTreeMap::new();
     for (mut item,_) in deeper{
-        while no_dot(&item).parent() != Some(&common){
-            item = parent_dot(&item)?;
+        while item.parent() != Some(&common){
+            item = (item.parent()?).into();
         }
         d2.insert(item,());
     }
@@ -64,8 +50,8 @@ mod test{
         let r = search_as_folders(v2).unwrap(); 
         assert_eq!(r,vec![
                   PathBuf::from("/hello/buddy"),
-                  PathBuf::from("/hello/venus/..."),
-                  PathBuf::from("/hello/world/..."),
+                  PathBuf::from("/hello/venus"),
+                  PathBuf::from("/hello/world"),
                   ]);
     }        
 
@@ -80,8 +66,8 @@ mod test{
         let v2:Vec<&Path> = (&vals).into_iter().map(|x|x as &Path).collect();
         let r = search_as_folders(v2).unwrap(); 
         assert_eq!(r,vec![
-                  PathBuf::from("/group/..."),
-                  PathBuf::from("/hello/..."),
+                  PathBuf::from("/group"),
+                  PathBuf::from("/hello"),
                   ]);
     }        
 


### PR DESCRIPTION
So, I think this is the easiest way to let you see the work,

This is not tab completed as I suggested in my original email, it just behaves slightly differently on the results.

If the results are more than the config it looks for the highest common folder of the results, and returns the first N direct children of that.

This has some advantages in that it shows you a shortlist of folders in a directory, but sometimes this is less effective than I had hoped.

For example in the amp folder "src" folder and a "target/.../.../.../src" folder, so typing src only shows 

```
src
target
```
even so "src .rs"  shows:
```
  src/errors.rs                                                                 
  src/lib.rs                                                                    
> src/main.rs                                                                   
  src/util                                                                      
  src/view
```
the last 2 are folders

Hope this is of interest, let me know what you think.

There are improvements I'd like to work on, possibly some mechanism for forcing a search at the current PWD.

maybe using "/" or ">" so
```
>src
```
would not include the target results.

This would be a lot of work though as it depends on really hacking around the bloodhound system somehow.

Anyway, I hope this is of interest to you,
If you like the direction let me know and I'll ponder how to get the ">" idea working

    