### PR TITLE
Add .editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# Trailing whitespaces have significance in Markdown
+[*.md]
+trim_trailing_whitespace = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,20 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-dependencies = [
- "memchr 0.1.11",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 dependencies = [
- "memchr 2.3.0",
+ "memchr",
 ]
 
 [[package]]
@@ -24,7 +15,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 dependencies = [
- "memchr 2.3.0",
+ "memchr",
 ]
 
 [[package]]
@@ -43,8 +34,7 @@ dependencies = [
  "luthor",
  "mio",
  "pad",
- "regex 0.1.80",
- "regex 1.3.4",
+ "regex 1.4.2",
  "scribe",
  "signal-hook",
  "smallvec",
@@ -614,15 +604,6 @@ checksum = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
@@ -919,47 +900,28 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-dependencies = [
- "aho-corasick 0.5.3",
- "memchr 0.1.11",
- "regex-syntax 0.3.9",
- "thread_local 0.2.7",
- "utf8-ranges 0.1.3",
-]
-
-[[package]]
-name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 dependencies = [
  "aho-corasick 0.6.4",
- "memchr 2.3.0",
+ "memchr",
  "regex-syntax 0.5.6",
  "thread_local 0.3.5",
- "utf8-ranges 1.0.0",
+ "utf8-ranges",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick 0.7.8",
- "memchr 2.3.0",
- "regex-syntax 0.6.14",
+ "memchr",
+ "regex-syntax 0.6.21",
  "thread_local 1.0.1",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 
 [[package]]
 name = "regex-syntax"
@@ -978,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "rustc-demangle"
@@ -1208,29 +1170,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-dependencies = [
- "kernel32-sys",
- "libc",
-]
-
-[[package]]
 name = "thread-scoped"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-dependencies = [
- "thread-id",
-]
 
 [[package]]
 name = "thread_local"
@@ -1326,12 +1269,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 
 [[package]]
 name = "utf8-ranges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ documentation = "https://amp.rs/docs"
 readme = "README.md"
 license-file = "LICENSE"
 keywords = ["text", "editor", "terminal", "modal"]
-edition="2018"
+edition = "2018"
 
 [build-dependencies]
-regex = "1.3.4"
+regex = "1.4.2"
 
 [dependencies]
 app_dirs = "1.2.1"
@@ -22,7 +22,7 @@ pad = "0.1.4"
 bloodhound = "0.5.4"
 luthor = "0.1.7"
 fragment = "0.3.1"
-regex = "^0.1"
+regex = "1.4.2"
 libc = "0.2.4"
 syntect = "2.1.0"
 termion = "1.5.1"

--- a/documentation/pages/configuration.md
+++ b/documentation/pages/configuration.md
@@ -57,6 +57,40 @@ line_wrapping: true
 
 When set to `true`, lines extending beyond the visible region are wrapped to the line below.
 
+### Remove Trailing Whitespace
+
+```yaml
+remove_trailing_whitespace: true
+```
+
+When set to `true`, whitespace characters found at the end of a line will be removed when the buffer is saved.
+
+### Ensure Trailing Newline
+
+```yaml
+ensure_trailing_newline: true
+```
+
+When set to `true`, and a newline does not exist at the end of the buffer, one will be inserted when the buffer is saved.
+
+### Use EditorConfig
+
+```yaml
+use_editorconfig: true
+```
+
+When set to `true`, amp will try to load a [.editorconfig](https://editorconfig.org) file from the workspace root if present.
+
+!!! warning
+    **Only a subset of the EditorConfig spec is supported**. More specifically, the following Amp configuration options can be overridden by their EditorConfig equivalents:
+
+    * `soft_tabs`
+    * `tab_width`
+    * `remove_trailing_whitespace`
+    * `ensure_trailing_newline`
+
+    Any other rules will be ignored, including nested .editorconfig files.
+
 ## File Format-Specific Options
 
 The `tab_width` and `soft_tabs` options can be configured on a per-extension basis:

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -9,8 +9,7 @@ use crate::models::application::modes::ConfirmMode;
 use scribe::buffer::{Buffer, Position, Range};
 
 pub fn save(app: &mut Application) -> Result {
-    remove_trailing_whitespace(app)?;
-    ensure_trailing_newline(app)?;
+    apply_preferences(app)?;
 
     // Slight duplication here, but we need to check for a buffer path without
     // borrowing the buffer for the full scope of this save command. That will
@@ -36,6 +35,25 @@ pub fn save(app: &mut Application) -> Result {
 
         Ok(())
     }
+}
+
+fn apply_preferences(app: &mut Application) -> Result {
+    let path = app
+        .workspace
+        .current_buffer()
+        .ok_or(BUFFER_MISSING)?
+        .path
+        .clone();
+
+    if app.preferences.borrow().remove_trailing_whitespace(path.as_ref()) {
+        remove_trailing_whitespace(app)?;
+    }
+
+    if app.preferences.borrow().ensure_trailing_newline(path.as_ref()) {
+        ensure_trailing_newline(app)?;
+    }
+
+    Ok(())
 }
 
 pub fn reload(app: &mut Application) -> Result {

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -99,7 +99,7 @@ fn get_gh_path(url: &str) -> errors::Result<&str> {
         static ref REGEX: Regex =
             Regex::new(r"^(?:https://|git@)github.com(?::|/)(.*?)(?:.git)?$").unwrap();
     }
-    REGEX.captures(url).and_then(|c| c.at(1)).chain_err(|| {
+    REGEX.captures(url).and_then(|c| c.get(1)).and_then(|c| Some(c.as_str())).chain_err(|| {
         "Failed to capture remote repo path"
     })
 }

--- a/src/models/application/editorconfig.rs
+++ b/src/models/application/editorconfig.rs
@@ -477,7 +477,33 @@ mod tests {
     }
 
     #[test]
-    fn glob_ranges() {
+    fn project_editorconfig() {
+        let config = EditorConfig::from_directory(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+        ).unwrap();
+
+        let md = config.get("README.md").unwrap();
+        assert_eq!(md.regex.as_str(), r"[^/]*\.md$");
+
+        let all = config.get("src/main.rs").unwrap();
+        assert_eq!(all.regex.as_str(), r"[^/]*$");
+
+        assert!(md.is_match("README.md"));
+        assert!(all.is_match("README.md"));
+        assert!(all.is_match("src/models/application/editorconfig.rs"));
+
+        assert!(!md.trim_trailing_whitespace.unwrap());
+
+        assert!(all.insert_final_newline.unwrap());
+        assert!(all.trim_trailing_whitespace.unwrap());
+        assert_eq!(all.end_of_line.unwrap(), EndOfLine::Lf);
+        assert_eq!(all.charset.unwrap(), Charset::Utf8);
+        assert_eq!(all.indent_style.unwrap(), IndentStyle::Space);
+        assert_eq!(all.indent_size.unwrap(), IndentSize::Width(4));
+    }
+
+    #[test]
+    fn glob_range() {
         assert_eq!(create_regex_range("0", "3"), Some("(0|1|2|3)".into()));
         assert_eq!(create_regex_range("0", "0"), Some("(0)".into()));
         assert_eq!(create_regex_range("4", "2"), Some("(2|3|4)".into()));

--- a/src/models/application/editorconfig.rs
+++ b/src/models/application/editorconfig.rs
@@ -1,0 +1,626 @@
+use core::ops::RangeInclusive;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use crate::errors::*;
+use regex::{self, Regex};
+
+lazy_static! {
+    static ref GLOB_SECTION_RE: Regex = Regex::new(r"^\[(.*)\]").unwrap();
+    static ref KEY_VALUE_PAIR_RE: Regex = Regex::new(r"^(\w+)\s?=\s?([-\w\d]+)").unwrap();
+
+    static ref GLOB_NUMERIC_RANGE_RE: Regex = Regex::new(r"^\{([+-]?\d+)\.\.([+-]?\d+)\}").unwrap();
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IndentStyle {
+    Tab,
+    Space,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IndentSize {
+    Tab,
+    Width(usize),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EndOfLine {
+    Lf,
+    Cr,
+    Crlf,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Charset {
+    Latin1,
+    Utf8,
+    Utf8Bom,
+    Utf16Be,
+    Utf16Le,
+}
+
+#[derive(Clone)]
+pub struct Section {
+    regex: Regex,
+
+    pub indent_style: Option<IndentStyle>,
+    pub indent_size: Option<IndentSize>,
+    pub tab_width: Option<usize>,
+    pub end_of_line: Option<EndOfLine>,
+    pub charset: Option<Charset>,
+    pub trim_trailing_whitespace: Option<bool>,
+    pub insert_final_newline: Option<bool>,
+}
+
+impl Section {
+    fn from(regex: Regex) -> Self {
+        Self {
+            regex,
+            indent_style: None,
+            indent_size: None,
+            tab_width: None,
+            end_of_line: None,
+            charset: None,
+            trim_trailing_whitespace: None,
+            insert_final_newline: None,
+        }
+    }
+
+    fn is_match(&self, filename: &str) -> bool {
+        self.regex.is_match(filename)
+    }
+
+    fn insert_property(&mut self, name: &str, value: &str) {
+        match &*name.to_ascii_lowercase() {
+            "indent_style" => {
+                self.indent_style = match &*value.to_ascii_lowercase() {
+                    "tab" => Some(IndentStyle::Tab),
+                    "space" => Some(IndentStyle::Space),
+                    _ => None,
+                };
+            },
+
+            "indent_size" => {
+                self.indent_size =
+                    if &*value.to_ascii_lowercase() == "tab" {
+                        Some(IndentSize::Tab)
+                    } else if let Ok(value) = value.parse::<usize>() {
+                        Some(IndentSize::Width(value))
+                    } else {
+                        None
+                    };
+            },
+
+            "tab_width" => {
+                self.tab_width = value.parse::<usize>().ok();
+            },
+
+            "end_of_line" => {
+                self.end_of_line = match &*value.to_ascii_lowercase() {
+                    "lf" => Some(EndOfLine::Lf),
+                    "cr" => Some(EndOfLine::Cr),
+                    "crlf" => Some(EndOfLine::Crlf),
+                    _ => None,
+                };
+            },
+
+            "charset" => {
+                self.charset = match &*value.to_ascii_lowercase() {
+                    "latin1" => Some(Charset::Latin1),
+                    "utf-8" => Some(Charset::Utf8),
+                    "utf-8-bom" => Some(Charset::Utf8Bom),
+                    "utf-16be" => Some(Charset::Utf16Be),
+                    "utf-16le" => Some(Charset::Utf16Le),
+                    _ => None,
+                };
+            },
+
+            "trim_trailing_whitespace" => {
+                self.trim_trailing_whitespace = match &*value.to_ascii_lowercase() {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                };
+            },
+
+            "insert_final_newline" => {
+                self.insert_final_newline = match &*value.to_ascii_lowercase() {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                };
+            },
+
+            _ => {},
+        };
+    }
+}
+
+pub struct EditorConfig {
+    sections: Vec<Section>,
+}
+
+impl EditorConfig {
+    pub fn from_directory(mut path: PathBuf) -> Result<Option<EditorConfig>> {
+        path.push(".editorconfig");
+
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(_) => return Ok(None),
+        };
+
+        load_from_file(&file)
+            .map(|sections| Some(EditorConfig { sections }))
+            .chain_err(|| "Failed to parse .editorconfig file")
+    }
+
+    pub fn get(&self, filename: &str) -> Option<&Section> {
+        for section in &self.sections {
+            if section.is_match(filename) {
+                return Some(section);
+            }
+        }
+
+        None
+    }
+}
+
+fn load_from_file(file: &File) -> Result<Vec<Section>> {
+    let reader = BufReader::new(file);
+
+    let mut last_glob = None;
+    let mut glob_list = vec![];
+    let mut line_num = 1;
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => break,
+        };
+
+        let line = line.trim();
+
+        // Ignore empty lines and comments
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+
+        if let Some(capture) = GLOB_SECTION_RE.captures(&line) {
+            if let Some(glob) = last_glob {
+                glob_list.push(glob);
+            }
+
+            if let Some(regex) = glob_to_regex(&capture[1]).and_then(|r| Regex::new(&r).ok()) {
+                last_glob = Some(Section::from(regex));
+            } else {
+                last_glob = None;
+            }
+        } else if let Some(capture) = KEY_VALUE_PAIR_RE.captures(&line) {
+            if let Some(ref mut glob) = last_glob {
+                glob.insert_property(&capture[1], &capture[2]);
+            }
+        } else {
+            return Err(format!("parse failure on line {}", line_num).into());
+        }
+
+        line_num += 1;
+    }
+
+    if let Some(glob) = last_glob {
+        glob_list.push(glob);
+    }
+
+    // We reverse the list here to preserve the property that always the last
+    // value that was specified for that property for a specific glob match
+    // will be used.
+    glob_list.reverse();
+    Ok(glob_list)
+}
+
+fn glob_to_regex(glob: &str) -> Option<String> {
+    Some(glob_to_regex_inner(glob)? + "$")
+}
+
+fn glob_to_regex_inner(glob: &str) -> Option<String> {
+    //
+    // EditorConfig specifies only a small amount of wildcard patterns:
+    //
+    //   | glob pattern | description
+    //   |--------------|-------------
+    //   | *            | matches any string of characters except /
+    //   | **           | matches any string of characters
+    //   | ?            | matches any single character except /
+    //   | [name]       | matches any single character between [ and ], no nesting allowed
+    //   | [!name]      | matches any single character _not_ between [ and ], no nesting allowed
+    //   | {a,b,c}      | matches any of the comma-separated strings between { and }, nesting allowed
+    //   | {num1..num2} | matches any integer number between num1 and num2 (inclusive), nesting allowed
+    //
+
+    let mut result = Vec::new();
+    let mut next_index = 0;
+
+    for (index, pattern) in glob.match_indices(&['\\', '*', '?', '[', '{', '/'][..]) {
+        if index < next_index {
+            continue;
+        }
+
+        // Add anything between last and current match to our result
+        result.push(regex::escape(&glob[next_index..index]));
+
+        match pattern {
+            "\\" => {
+                if let Some(next) = glob.get(index+1..=index+1) {
+                    result.push(next.to_string());
+                    next_index = index + 2;
+                } else { // We're at the end of the glob
+                    result.push(r"\\".to_string());
+                    next_index = index + 1;
+                }
+            },
+
+            "?" => {
+                result.push(r"[^/]".to_string());
+                next_index = index + 1;
+            },
+
+            "*" => {
+                if index < glob.len()-1 && &glob[index+1..=index+1] == "*" {
+                    result.push(".*".to_string());
+                    next_index = index + 2;
+                } else {
+                    result.push(r"[^/]*".to_string());
+                    next_index = index + 1;
+                }
+            },
+
+            "[" => {
+                let consumed = parse_brackets(&glob[index..], &mut result)?;
+                next_index = index + consumed;
+            },
+
+            "{" => {
+                let consumed = parse_braces(&glob[index..], &mut result)?;
+                next_index = index + consumed;
+            },
+
+            "/" => {
+                if index + 3 < glob.len() && &glob[index..=index+3] == "/**/" {
+                    result.push(r"(/|/.*/)".to_string());
+                    next_index = index + 4;
+                } else {
+                    result.push("/".to_string());
+                    next_index = index + 1;
+                }
+            },
+
+            #[cfg(debug_assertions)]
+            _ => unreachable!(),
+
+            #[cfg(not(debug_assertions))]
+            _ => return None,
+        }
+    }
+
+    result.push(regex::escape(&glob[next_index..]));
+    Some(result.join(""))
+}
+
+fn parse_brackets(glob: &str, result: &mut Vec<String>) -> Option<usize> {
+    let end_index = find_end_index(glob, '[', ']')?;
+
+    // Ignore empty brackets
+    if end_index == 1 {
+        return Some(2);
+    } else if end_index == 2 && &glob[1..=1] == "!" {
+        return Some(3);
+    }
+
+    if glob.get(1..=1)? == "!" {
+        result.push("[^".to_string());
+        result.push(regex::escape(&glob[2..end_index]));
+    } else {
+        result.push("[".to_string());
+        result.push(regex::escape(&glob[1..end_index]));
+    }
+
+    result.push("]".to_string());
+    Some(end_index + 1)
+}
+
+fn parse_braces(glob: &str, result: &mut Vec<String>) -> Option<usize> {
+    if let Some(cap) = GLOB_NUMERIC_RANGE_RE.captures(glob) {
+        result.push(create_regex_range(&cap[1], &cap[2])?);
+        Some(cap.get(0)?.end())
+    } else {
+        let end_index = find_end_index(glob, '{', '}')?;
+
+        let glob = &glob[1..end_index];
+        if glob.len() == 0 {
+            return Some(2);
+        }
+
+        let mut start_index = 0;
+        result.push("(".to_string()); // open group
+        for (index, _) in glob.match_indices(',') {
+            if index > 0 && &glob[index-1..=index-1] == "\\" {
+                continue;
+            }
+
+            if index - start_index > 0 {
+                let glob = &glob[start_index..index];
+                let nesting_level = parse_nesting_level(glob);
+
+                if nesting_level == 0 {
+                    result.push("(".to_string());
+                    result.push(glob_to_regex_inner(glob)?);
+                    result.push(")|".to_string());
+                } else {
+                    continue;
+                }
+            } else {
+                result.push("$|".to_string());
+            }
+
+            start_index = index + 1;
+        }
+
+        result.push("(".to_string());
+        result.push(glob_to_regex_inner(&glob[start_index..])?);
+        result.push(")".to_string());
+
+        result.push(")".to_string()); // close group
+        Some(end_index + 1)
+    }
+}
+
+fn create_regex_range(start: &str, end: &str) -> Option<String> {
+    let mut range = create_range(start, end)?
+        .into_iter()
+        .fold(String::new(), |acc, n| acc + &n.to_string() + "|");
+
+    // Remove last pipe
+    range.pop();
+
+    Some(format!("({})", range))
+}
+
+fn create_range(start: &str, end: &str) -> Option<RangeInclusive<i32>> {
+    let start = start.parse::<i32>().ok()?;
+    let end = end.parse::<i32>().ok()?;
+
+    if start <= end {
+        Some(start..=end)
+    } else {
+        Some(end..=start)
+    }
+}
+
+fn find_end_index(input: &str, open: char, close: char) -> Option<usize> {
+    let mut level = 0;
+    let mut last_char = None;
+    let mut last_close_index = None;
+
+    for (index, c) in input.char_indices() {
+        if c == open {
+            if last_char.is_none() || (last_char.is_some() && last_char.unwrap() != '\\') {
+                level += 1;
+            }
+        } else if c == close {
+            if last_char.is_none() || (last_char.is_some() && last_char.unwrap() != '\\') {
+                last_close_index = Some(index);
+                level -= 1;
+            }
+        }
+
+        if level == 0 {
+            return Some(index);
+        }
+
+        last_char = Some(c);
+    }
+
+    last_close_index
+}
+
+fn parse_nesting_level(input: &str) -> i32 {
+    let mut level = 0;
+    let mut last_char = None;
+
+    for c in input.chars() {
+        if c == '{' || c == '[' {
+            if last_char.is_none() || (last_char.is_some() && last_char.unwrap() != '\\') {
+                level += 1;
+            }
+        } else if c == '}' || c == ']' {
+            if last_char.is_none() || (last_char.is_some() && last_char.unwrap() != '\\') {
+                level -= 1;
+            }
+        }
+
+        last_char = Some(c);
+    }
+
+    level
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    macro_rules! glob_lit_matches {
+        ($glob:literal, $expanded:literal) => {
+            assert_eq!(glob_to_regex($glob).unwrap(), $expanded);
+        };
+    }
+
+    macro_rules! glob_matches {
+        ($glob:literal, $path:literal) => {
+            assert!(Regex::new(&glob_to_regex($glob).unwrap()).unwrap().is_match($path));
+        };
+        ($glob:literal, $path: literal, $($rest:literal),+) => {
+            glob_matches!($glob, $path);
+            glob_matches!($glob, $($rest),+);
+        };
+    }
+
+    macro_rules! glob_matches_not {
+        ($glob:literal, $path:literal) => {
+            assert!(!Regex::new(&glob_to_regex($glob).unwrap()).unwrap().is_match($path));
+        };
+        ($glob:literal, $path: literal, $($rest:literal),+) => {
+            glob_matches_not!($glob, $path);
+            glob_matches_not!($glob, $($rest),+);
+        };
+    }
+
+    #[test]
+    fn glob_ranges() {
+        assert_eq!(create_regex_range("0", "3"), Some("(0|1|2|3)".into()));
+        assert_eq!(create_regex_range("0", "0"), Some("(0)".into()));
+        assert_eq!(create_regex_range("4", "2"), Some("(2|3|4)".into()));
+        assert_eq!(create_regex_range("-4", "-2"), Some("(-4|-3|-2)".into()));
+        assert_eq!(create_regex_range("-2", "2"), Some("(-2|-1|0|1|2)".into()));
+    }
+
+    #[test]
+    fn single_star_globs() {
+        glob_lit_matches!("*", r"[^/]*$");
+        glob_matches!("*", "src/main.rs", "README.md");
+
+        glob_lit_matches!("*.rs", r"[^/]*\.rs$");
+        glob_matches_not!("*.rs", "README.md", "src/input/key_map/default.yml");
+
+        glob_lit_matches!("a*/z", "a[^/]*/z$");
+        glob_matches!("a*/z", "a/z", "ab/z", "abcdefg/z");
+        glob_matches_not!("a*/z", "a/b/z");
+    }
+
+    #[test]
+    fn double_star_globs() {
+        glob_lit_matches!("**/*.rs", r".*/[^/]*\.rs$");
+        glob_matches!("**/*.rs", "src/main.rs");
+        glob_matches_not!("**/*.rs", "README.md");
+
+        glob_lit_matches!("src/**/mod.rs", r"src(/|/.*/)mod\.rs$");
+        glob_matches!("src/**/mod.rs", "src/commands/mod.rs", "src/models/application/mod.rs");
+        glob_matches_not!("src/**/mod.rs", "src/commands/buffer.rs", "src/view/style.rs");
+    }
+
+    #[test]
+    fn question_mark_globs() {
+        glob_lit_matches!("a?c/d", r"a[^/]c/d$");
+        glob_matches!("a?c/d", "abc/d");
+        glob_matches_not!("a?c/d", "a/c/d", "ac/d");
+    }
+
+    #[test]
+    fn braces_number_ranges_globs() {
+        glob_lit_matches!("a/t{1..3}/b", "a/t(1|2|3)/b$");
+        glob_matches!("a/t{1..3}/b", "a/t1/b", "a/t3/b");
+        glob_matches_not!("a/t{1..3}/b", "a/t/b/", "a/t0/b", "a/t4/b");
+
+        glob_lit_matches!("a/t{-20..-17}/b", "a/t(-20|-19|-18|-17)/b$");
+        glob_matches!("a/t{-20..-17}/b", "a/t-20/b", "a/t-17/b");
+        glob_matches_not!("a/t{-20..-17}/b", "a/t-21/b", "a/t-16/b");
+
+        glob_lit_matches!("a/t{-2..1}/b", "a/t(-2|-1|0|1)/b$");
+        glob_matches!("a/t{-2..1}/b", "a/t-2/b", "a/t0/b", "a/t1/b");
+    }
+
+    #[test]
+    fn braces_any_globs() {
+        glob_lit_matches!("*.{rs,md,yml}", r"[^/]*\.((rs)|(md)|(yml))$");
+        glob_matches!("*.{rs,md,yml}", "src/main.rs", "README.md", "src/input/key_map/default.yml");
+        glob_matches_not!("*.{rs,md,yml}", ".gitmodules", "src/main.c");
+
+        glob_lit_matches!("*{.rs,.md,.yml}", r"[^/]*((\.rs)|(\.md)|(\.yml))$");
+        glob_matches!("*{.rs,.md,.yml}", "src/main.rs", "README.md", "src/input/key_map/default.yml");
+        glob_matches_not!("*{.rs,.md,.yml}", ".gitmodules", "src/main.c");
+
+        glob_lit_matches!("*.{r\\,s,m\\,d,ym\\,l}", r"[^/]*\.((r,s)|(m,d)|(ym,l))$");
+        glob_matches!("*.{r\\,s,m\\,d,ym\\,l}", "src/main.r,s", "README.m,d", "src/input/key_map/default.ym,l");
+        glob_matches_not!("*.{r\\,s,m\\,d,ym\\,l}", "src/main.rs", "README.md", "src/input/key_map/default.yml");
+
+        glob_lit_matches!("*.{,rs,md,yml}", r"[^/]*\.($|(rs)|(md)|(yml))$");
+        glob_matches!("*.{,rs,md,yml}", "src/main.rs", "README.md", "src/input/key_map/default.yml", "test.");
+        glob_matches_not!("*.{,rs,md,yml}", "test", ".gitmodules");
+
+        glob_lit_matches!("*.{}", r"[^/]*\.$");
+        glob_matches!("*.{}", "test.");
+        glob_matches_not!("*.{}", "src/main.rs", "README.md", ".gitmodules");
+
+        glob_lit_matches!("src/ma{}in.rs", r"src/main\.rs$");
+        glob_matches!("src/ma{}in.rs", "src/main.rs");
+    }
+
+    #[test]
+    fn nested_braces_any_globs() {
+        glob_lit_matches!("x{a,b,z[123]}", "x((a)|(b)|(z[123]))$");
+        glob_matches!("x{a,b,z[123]}", "xa", "xb", "xz1", "xz3");
+        glob_matches_not!("x{a,b,z[123]}", "xc", "x1", "x3", "xa1", "xb1", "x");
+
+        glob_lit_matches!("x{a,b{1,2,3}}", "x((a)|(b((1)|(2)|(3))))$");
+        glob_matches!("x{a,b{1,2,3}}", "xa", "xb1", "xb2", "xb3");
+        glob_matches_not!("x{a,b{1,2,3}}", "x", "xb", "xb4", "xba", "xab");
+
+        glob_lit_matches!("x{a,{1,2,3}}", "x((a)|(((1)|(2)|(3))))$");
+        glob_matches!("x{a,{1,2,3}}", "xa", "x1", "x2", "x3");
+        glob_matches_not!("x{a,{1,2,3}}", "x", "xb", "xa1", "xba", "xab");
+
+        glob_lit_matches!("x{a,b{1,2,3},z[!123]}", "x((a)|(b((1)|(2)|(3)))|(z[^123]))$");
+        glob_matches!("x{a,b{1,2,3},z[!123]}", "xa", "xb1", "xb2", "xb3", "xz4", "xzA");
+        glob_matches_not!("x{a,b{1,2,3},z[!123]}", "xc", "xb", "xz", "xa1", "xab", "xz1", "xz3");
+
+        glob_lit_matches!("x{1,{2..4},5}", "x((1)|((2|3|4))|(5))$");
+        glob_matches!("x{1,{2..4},5}", "x1", "x2", "x3", "x4", "x5");
+        glob_matches_not!("x{1,{2..4},5}", "x0", "x6");
+    }
+
+    #[test]
+    fn brackets_globs() {
+        glob_lit_matches!("[abcdef].rs", r"[abcdef]\.rs$");
+        glob_matches!("[abcdef].rs", "a.rs", "c.rs", "f.rs");
+        glob_matches_not!("[abcdef].rs", "s.rs", "q.rs", "y.rs");
+
+        glob_lit_matches!("a[c]e.rs", r"a[c]e\.rs$");
+        glob_matches!("a[c]e.rs", "ace.rs");
+        glob_matches_not!("a[c]e.rs", "abe.rs");
+
+        glob_lit_matches!("a[]e.rs", r"ae\.rs$");
+        glob_matches!("a[]e.rs", "ae.rs");
+        glob_matches_not!("a[]e.rs", "ace.rs");
+
+        glob_lit_matches!("a[b[c].rs", r"a[b\[c]\.rs$");
+        glob_matches!("a[b[c].rs", "ab.rs", "ac.rs", "a[.rs");
+        glob_matches_not!("a[b[c].rs", "abc.rs", "ab[c.rs");
+    }
+
+    #[test]
+    fn brackets_not_globs() {
+        glob_lit_matches!("[!abcdef].rs", r"[^abcdef]\.rs$");
+        glob_matches!("[!abcdef].rs", "s.rs", "q.rs", "y.rs");
+        glob_matches_not!("[!abcdef].rs", "a.rs", "c.rs", "f.rs");
+
+        glob_lit_matches!("a[!c]e.rs", r"a[^c]e\.rs$");
+        glob_matches!("a[!c]e.rs", "abe.rs");
+        glob_matches_not!("a[!c]e.rs", "ace.rs");
+
+        glob_lit_matches!("a[!]e.rs", r"ae\.rs$");
+        glob_matches!("a[!]e.rs", "ae.rs");
+        glob_matches_not!("a[!]e.rs", "ace.rs");
+    }
+
+    #[test]
+    fn nested_brackets_globs() {
+        glob_lit_matches!("[ab[cd]ef].rs", r"[ab\[cd\]ef]\.rs$");
+        glob_matches!("[ab[cd]ef].rs", "a.rs", "b.rs", "[.rs", "c.rs", "d.rs", "].rs", "e.rs", "f.rs");
+        glob_matches_not!("[ab[cd]ef].rs", "g.rs", ".rs");
+
+        glob_lit_matches!("[ab[cd]ef].rs", r"[ab\[cd\]ef]\.rs$");
+        glob_matches!("[ab[cd]ef].rs", "a.rs", "b.rs", "[.rs", "c.rs", "d.rs", "].rs", "e.rs", "f.rs");
+        glob_matches_not!("[ab[cd]ef].rs", "g.rs", ".rs");
+    }
+}

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -1,4 +1,5 @@
 mod clipboard;
+mod editorconfig;
 mod event;
 pub mod modes;
 mod preferences;

--- a/src/models/application/preferences/default.yml
+++ b/src/models/application/preferences/default.yml
@@ -4,6 +4,10 @@ soft_tabs: true
 line_length_guide: 80
 line_wrapping: true
 
+use_editorconfig: true
+remove_trailing_whitespace: true
+ensure_trailing_newline: true
+
 open_mode:
   exclusions:
     - "**/.git"

--- a/src/models/application/preferences/mod.rs
+++ b/src/models/application/preferences/mod.rs
@@ -10,18 +10,20 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use crate::yaml::yaml::{Hash, Yaml, YamlLoader};
 use crate::models::application::modes::SearchSelectConfig;
-use crate::models::application::editorconfig::EditorConfig;
+use crate::models::application::editorconfig::{self, EditorConfig};
 
 const APP_INFO: AppInfo = AppInfo {
     name: "amp",
     author: "Jordan MacDonald",
 };
+const ENSURE_TRAILING_NEWLINE_KEY: &str = "ensure_trailing_newline";
 const FILE_NAME: &str = "config.yml";
 const LINE_COMMENT_PREFIX_KEY: &str = "line_comment_prefix";
 const LINE_LENGTH_GUIDE_KEY: &str = "line_length_guide";
 const LINE_WRAPPING_KEY: &str = "line_wrapping";
 const OPEN_MODE_EXCLUSIONS_KEY: &str = "exclusions";
 const OPEN_MODE_KEY: &str = "open_mode";
+const REMOVE_TRAILING_WHITESPACE_KEY: &str = "remove_trailing_whitespace";
 const SEARCH_SELECT_KEY: &str = "search_select";
 const SOFT_TABS_KEY: &str = "soft_tabs";
 const SYNTAX_PATH: &str = "syntaxes";
@@ -30,6 +32,7 @@ const THEME_KEY: &str = "theme";
 const THEME_PATH: &str = "themes";
 const TYPES_KEY: &str = "types";
 const TYPES_SYNTAX_KEY: &str = "syntax";
+const USE_EDITORCONFIG_KEY: &str = "use_editorconfig";
 
 /// Loads, creates, and provides default values for application preferences.
 /// Values are immutable once loaded, with the exception of those that provide
@@ -157,6 +160,19 @@ impl Preferences {
     }
 
     pub fn tab_width(&self, path: Option<&PathBuf>) -> usize {
+        if let Some(value) = self.get_editorconfig(path).and_then(|p| p.indent_size) {
+            match value {
+                editorconfig::IndentSize::Tab => {
+                    // If indent_size = tab, then use tab_width
+                    if let Some(value) = self.get_editorconfig(path).and_then(|p| p.tab_width) {
+                        // If tab_width was specified, use that - otherwise fall back to editor preferences.
+                        return value;
+                    }
+                },
+                editorconfig::IndentSize::Width(value) => return value,
+            }
+        }
+
         self.data
             .as_ref()
             .and_then(|data| {
@@ -189,6 +205,10 @@ impl Preferences {
     }
 
     pub fn soft_tabs(&self, path: Option<&PathBuf>) -> bool {
+        if let Some(value) = self.get_editorconfig(path).and_then(|p| p.indent_style) {
+            return value == editorconfig::IndentStyle::Space;
+        }
+
         self.data
             .as_ref()
             .and_then(|data| {
@@ -312,6 +332,81 @@ impl Preferences {
         open::exclusions::parse(exclusions)
             .chain_err(|| "Failed to parse default open mode exclusions")
             .map(Some)
+    }
+
+    pub fn remove_trailing_whitespace(&self, path: Option<&PathBuf>) -> bool {
+        if let Some(value) = self.get_editorconfig(path).and_then(|p| p.trim_trailing_whitespace) {
+            return value;
+        }
+
+        self.data
+            .as_ref()
+            .and_then(|data| if let Yaml::Boolean(remove_trailing) = data[REMOVE_TRAILING_WHITESPACE_KEY] {
+                          Some(remove_trailing)
+                      } else {
+                          None
+                      })
+            .unwrap_or_else(|| {
+                self.default[REMOVE_TRAILING_WHITESPACE_KEY].as_bool()
+                    .expect("Couldn't find default remove_trailing_whitespace setting!")
+            })
+    }
+
+    pub fn ensure_trailing_newline(&self, path: Option<&PathBuf>) -> bool {
+        if let Some(value) = self.get_editorconfig(path).and_then(|p| p.insert_final_newline) {
+            return value;
+        }
+
+        self.data
+            .as_ref()
+            .and_then(|data| if let Yaml::Boolean(final_newline) = data[ENSURE_TRAILING_NEWLINE_KEY] {
+                          Some(final_newline)
+                      } else {
+                          None
+                      })
+            .unwrap_or_else(|| {
+                self.default[ENSURE_TRAILING_NEWLINE_KEY].as_bool()
+                    .expect("Couldn't find default ensure_trailing_newline setting!")
+            })
+    }
+
+    pub fn use_editorconfig(&self) -> bool {
+        if self.editorconfig.is_none() {
+            return false;
+        }
+
+        self.data
+            .as_ref()
+            .and_then(|data| if let Yaml::Boolean(use_ec) = data[USE_EDITORCONFIG_KEY] {
+                          Some(use_ec)
+                      } else {
+                          None
+                      })
+            .unwrap_or_else(|| {
+                self.default[USE_EDITORCONFIG_KEY].as_bool()
+                    .expect("Couldn't find default use_editorconfig setting!")
+            })
+    }
+
+    /// Disable .editorconfig support on test configurations to avoid a lot of false test-failures.
+    #[cfg(test)]
+    fn get_editorconfig(&self, _path: Option<&PathBuf>) -> Option<&editorconfig::Section> {
+        None
+    }
+
+    /// Returns the applicable .editorconfig section for a specific file.
+    #[cfg(not(test))]
+    fn get_editorconfig(&self, path: Option<&PathBuf>) -> Option<&editorconfig::Section> {
+        if self.use_editorconfig() {
+            let path = path?.to_str()?;
+
+            // If the editorconfig could have rules for this file, return them.
+            self.editorconfig
+                .as_ref()?
+                .get(&*path)
+        } else {
+            None
+        }
     }
 }
 
@@ -661,6 +756,30 @@ mod tests {
 
         assert_eq!(preferences.line_comment_prefix(&PathBuf::from("preferences.abc")),
                    None);
+    }
+
+    #[test]
+    fn preferences_returns_user_defined_remove_trailing_whitespace() {
+        let data = YamlLoader::load_from_str("remove_trailing_whitespace: false").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.remove_trailing_whitespace(Some(&PathBuf::from("preferences.rs"))), false);
+    }
+
+    #[test]
+    fn preferences_returns_user_defined_ensure_trailing_newline() {
+        let data = YamlLoader::load_from_str("ensure_trailing_newline: false").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.ensure_trailing_newline(Some(&PathBuf::from("preferences.rs"))), false);
+    }
+
+    #[test]
+    fn preferences_returns_user_defined_use_editorconfig() {
+        let data = YamlLoader::load_from_str("use_editorconfig: false").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.use_editorconfig(), false);
     }
 
     #[test]


### PR DESCRIPTION
First off I just want to say that I really like amp! It already has replaced vim for me!

Anyway, this addresses #18.

Currently, only `indent_style`, `indent_size`, `tab_width`, `trim_trailing_whitespace` and `insert_final_newline` are supported.
I also added an .editorconfig file for this repo.

~~(`tab_width` needs still some work, this setting is not yet respected in the renderer.)~~

I'm sending this now to get some comments on the current implementation (if it is ok), and further to discuss how to handle the [`end_of_line`](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#end_of_line) and [`charset`](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#charset) properties. 
From what I saw, there is currently no real handling for different file-encodings (everyone should be using UTF-8 anyway but it is part of .editorconfig spec). Same goes for line-endings handling.

~~Also some tests still need to be written to test the .editorconfig functionality.~~