### PR TITLE
Create snapcraft.yaml to add snap support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: amp
+version: git
+summary: "A complete text editor for your terminal."
+description: |
+  Heavily inspired by Vi/Vim. Amp aims to take the core interaction model
+  of Vim, simplify it, and bundle in the essential features required for
+  a modern text editor.
+
+grade: stable
+confinement: classic
+
+parts:
+  amp:
+    plugin: rust
+    source: ./
+    build-packages:
+      - python
+      - libxmu-dev
+      - libssl-dev
+      - pkg-config
+      - cmake
+
+apps:
+  amp:
+    command: bin/amp


### PR DESCRIPTION
I created a snap package of amp so it can be featured to the millions of Linux users installing apps from the [Snap Store](https://snapcraft.io/store). If you're willing to publish this under the amp project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the amp name](https://snapcraft.io/register-snap).

The snap file created by snapcraft can then be released in the Snap Store with snap push --release stable *.snap. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

Once in the snap store, you’ll need to [request classic confinement](https://forum.snapcraft.io/t/process-for-reviewing-classic-confinement-snaps/1460) with a [forum post](https://forum.snapcraft.io/), because amp will need to be unconfined (via classic confinement) so it has access to the entire filesystem.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of amp, and push them to the store automatically.

Thanks for making amp, don't tell the nano developers I prefer it! :)