### PR TITLE
Fix buffer::outdent_line when using hard tabs

### DIFF
--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -423,8 +423,8 @@ pub fn outdent_line(app: &mut Application) -> Result {
                 if content.chars().next() == Some('\t') {
                     space_char_count = 1;
                 }
-           	} else {
-           		// We're looking for spaces.
+            } else {
+                // We're looking for spaces.
                 for character in content.chars().take(tab_content.chars().count()) {
                     if character == ' ' {
                         space_char_count += 1;

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -418,12 +418,20 @@ pub fn outdent_line(app: &mut Application) -> Result {
             let mut space_char_count = 0;
 
             // Check for leading whitespace.
-            for character in content.chars().take(tab_content.chars().count()) {
-                if character == ' ' {
-                    space_char_count += 1;
-                } else {
-                    // We've run into a non-whitespace character; stop here.
-                    break;
+            if tab_content.chars().next().unwrap() == '\t' {
+                // We're looking for a tab character.
+                if content.chars().next().unwrap() == '\t' {
+                    space_char_count = 1;
+                }
+           	} else {
+           		// We're looking for spaces.
+                for character in content.chars().take(tab_content.chars().count()) {
+                    if character == ' ' {
+                        space_char_count += 1;
+                    } else {
+                        // We've run into a non-whitespace character; stop here.
+                        break;
+                    }
                 }
             }
 

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -418,9 +418,9 @@ pub fn outdent_line(app: &mut Application) -> Result {
             let mut space_char_count = 0;
 
             // Check for leading whitespace.
-            if tab_content.chars().next().unwrap() == '\t' {
+            if tab_content.chars().next() == Some('\t') {
                 // We're looking for a tab character.
-                if content.chars().next().unwrap() == '\t' {
+                if content.chars().next() == Some('\t') {
                     space_char_count = 1;
                 }
            	} else {


### PR DESCRIPTION
`buffer::outdent_line` didn't work when using hard tabs for indentation, because the function itself was hardcoded to look for space characters.

I added a condition to make it look for tabs when it should.

I've tested the fix both for hard tabs and spaces indents, and everything works as it should so far. Consider ready to merge.