### PR TITLE
add python3 to build dependencies

### DIFF
--- a/documentation/pages/installation.md
+++ b/documentation/pages/installation.md
@@ -35,10 +35,11 @@ brew tap jmacdonald/amp && brew install amp
 * `openssl`
 * `zlib`
 
-### Build Dependencies
+### Build dependencies
 
 * `cmake`
 * `rust`
+* `python3` if building on Linux
 
 ### Building
 


### PR DESCRIPTION
Building on some architectures fails if Python3 is not present: https://travis-ci.org/void-linux/void-packages/builds/652779379