### PR TITLE
Add `dyn` to trait objects

### DIFF
--- a/src/presenters/modes/search_select.rs
+++ b/src/presenters/modes/search_select.rs
@@ -9,7 +9,7 @@ use scribe::buffer::Position;
 use crate::view::{Colors, StatusLineData, Style, View};
 use unicode_segmentation::UnicodeSegmentation;
 
-pub fn display<T: Display>(workspace: &mut Workspace, mode: &mut SearchSelectMode<T>, view: &mut View) -> Result<()> {
+pub fn display<T: Display>(workspace: &mut Workspace, mode: &mut dyn SearchSelectMode<T>, view: &mut View) -> Result<()> {
     let data;
     let padded_message;
     let mut presenter = view.build_presenter()?;

--- a/src/view/buffer/renderer.rs
+++ b/src/view/buffer/renderer.rs
@@ -32,14 +32,14 @@ pub struct BufferRenderer<'a, 'p> {
     render_cache: &'a Rc<RefCell<HashMap<usize, RenderState>>>,
     screen_position: Position,
     scroll_offset: usize,
-    terminal: &'a Terminal,
+    terminal: &'a dyn Terminal,
     terminal_buffer: &'a mut TerminalBuffer<'p>,
     theme: &'a Theme,
 }
 
 impl<'a, 'p> BufferRenderer<'a, 'p> {
     pub fn new(buffer: &'a Buffer, highlights: Option<&'a [Range]>,
-    scroll_offset: usize, terminal: &'a Terminal, theme: &'a Theme,
+    scroll_offset: usize, terminal: &'a dyn Terminal, theme: &'a Theme,
     preferences: &'a Preferences,
     render_cache: &'a Rc<RefCell<HashMap<usize, RenderState>>>,
     terminal_buffer: &'a mut TerminalBuffer<'p>) -> BufferRenderer<'a, 'p> {
@@ -216,7 +216,7 @@ impl<'a, 'p> BufferRenderer<'a, 'p> {
         !self.before_visible_content() && !self.after_visible_content()
     }
 
-    pub fn render(&mut self, lines: LineIterator<'p>, mut lexeme_mapper: Option<&mut LexemeMapper>) -> Result<Option<Position>> {
+    pub fn render(&mut self, lines: LineIterator<'p>, mut lexeme_mapper: Option<&mut dyn LexemeMapper>) -> Result<Option<Position>> {
         self.terminal.set_cursor(None);
         // Print the first line number. Others will
         // be handled as newlines are encountered.

--- a/src/view/buffer/scrollable_region.rs
+++ b/src/view/buffer/scrollable_region.rs
@@ -8,12 +8,12 @@ use crate::view::terminal::Terminal;
 /// Used to determine visible ranges of lines based on previous state,
 /// explicit line focus, and common scrolling implementation behaviours.
 pub struct ScrollableRegion {
-    terminal: Arc<Box<Terminal + Sync + Send + 'static>>,
+    terminal: Arc<Box<dyn Terminal + Sync + Send + 'static>>,
     line_offset: usize,
 }
 
 impl ScrollableRegion {
-    pub fn new(terminal: Arc<Box<Terminal + Sync + Send + 'static>>) -> ScrollableRegion {
+    pub fn new(terminal: Arc<Box<dyn Terminal + Sync + Send + 'static>>) -> ScrollableRegion {
         ScrollableRegion {
             terminal,
             line_offset: 0,

--- a/src/view/event_listener.rs
+++ b/src/view/event_listener.rs
@@ -5,7 +5,7 @@ use std::thread;
 use crate::view::Terminal;
 
 pub struct EventListener {
-    terminal: Arc<Box<Terminal + Sync + Send + 'static>>,
+    terminal: Arc<Box<dyn Terminal + Sync + Send + 'static>>,
     events: Sender<Event>,
     killswitch: Receiver<()>
 }
@@ -13,7 +13,7 @@ pub struct EventListener {
 impl EventListener {
     /// Spins up a thread that loops forever, waiting on terminal events
     /// and forwarding those to the application event channel.
-    pub fn start(terminal: Arc<Box<Terminal + Sync + Send + 'static>>, events: Sender<Event>, killswitch: Receiver<()>) {
+    pub fn start(terminal: Arc<Box<dyn Terminal + Sync + Send + 'static>>, events: Sender<Event>, killswitch: Receiver<()>) {
         thread::spawn(move || {
             EventListener { terminal, events, killswitch }.listen();
         });

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -35,7 +35,7 @@ use syntect::highlighting::ThemeSet;
 const RENDER_CACHE_FREQUENCY: usize = 100;
 
 pub struct View {
-    terminal: Arc<Box<Terminal + Sync + Send + 'static>>,
+    terminal: Arc<Box<dyn Terminal + Sync + Send + 'static>>,
     scrollable_regions: HashMap<usize, ScrollableRegion>,
     render_caches: HashMap<usize, Rc<RefCell<HashMap<usize, RenderState>>>>,
     pub theme_set: ThemeSet,

--- a/src/view/presenter.rs
+++ b/src/view/presenter.rs
@@ -71,7 +71,7 @@ impl<'p> Presenter<'p> {
         self.view.terminal.present();
     }
 
-    pub fn print_buffer(&mut self, buffer: &Buffer, buffer_data: &'p str, highlights: Option<&[Range]>, lexeme_mapper: Option<&'p mut LexemeMapper>) -> Result<()> {
+    pub fn print_buffer(&mut self, buffer: &Buffer, buffer_data: &'p str, highlights: Option<&[Range]>, lexeme_mapper: Option<&'p mut dyn LexemeMapper>) -> Result<()> {
         let scroll_offset = self.view.get_region(buffer)?.line_offset();
         let lines = LineIterator::new(buffer_data);
 

--- a/src/view/terminal/mod.rs
+++ b/src/view/terminal/mod.rs
@@ -32,11 +32,11 @@ pub trait Terminal {
 }
 
 #[cfg(not(any(test, feature = "bench")))]
-pub fn build_terminal() -> Result<Arc<Box<Terminal + Sync + Send + 'static>>> {
+pub fn build_terminal() -> Result<Arc<Box<dyn Terminal + Sync + Send + 'static>>> {
     Ok(Arc::new(Box::new(TermionTerminal::new()?)))
 }
 
 #[cfg(any(test, feature = "bench"))]
-pub fn build_terminal() -> Result<Arc<Box<Terminal + Sync + Send + 'static>>> {
+pub fn build_terminal() -> Result<Arc<Box<dyn Terminal + Sync + Send + 'static>>> {
     Ok(Arc::new(Box::new(TestTerminal::new())))
 }

--- a/src/view/terminal/termion_terminal.rs
+++ b/src/view/terminal/termion_terminal.rs
@@ -334,7 +334,7 @@ fn create_output_instance() -> BufWriter<RawTerminal<Stdout>> {
     BufWriter::with_capacity(1_048_576, stdout().into_raw_mode().unwrap())
 }
 
-fn map_style(style: Style) -> Option<Box<Display>> {
+fn map_style(style: Style) -> Option<Box<dyn Display>> {
     match style {
         Style::Default => None,
         Style::Bold => Some(Box::new(style::Bold)),


### PR DESCRIPTION
As the commit message says, not using `dyn` on trait objects is currently deprecated. Nothing is functionally different between using `dyn` and not using it (as of right now, anyway), although cargo throws a few less warnings as a result of the change.