### PR TITLE
Remove redundant static lifetimes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,9 +5,9 @@ error_chain! {
     }
 }
 
-pub static SEARCH_QUERY_MISSING: &'static str = "No search query";
-pub static NO_SEARCH_RESULTS: &'static str = "No search results available";
-pub static BUFFER_MISSING: &'static str = "No buffer available";
-pub static BUFFER_PATH_MISSING: &'static str = "No path found for the current buffer";
-pub static CURRENT_LINE_MISSING: &'static str = "The current line couldn't be found in the buffer";
-pub static SCROLL_TO_CURSOR_FAILED: &'static str = "Failed to scroll to cursor position";
+pub static SEARCH_QUERY_MISSING: &str = "No search query";
+pub static NO_SEARCH_RESULTS: &str = "No search results available";
+pub static BUFFER_MISSING: &str = "No buffer available";
+pub static BUFFER_PATH_MISSING: &str = "No path found for the current buffer";
+pub static CURRENT_LINE_MISSING: &str = "The current line couldn't be found in the buffer";
+pub static SCROLL_TO_CURSOR_FAILED: &str = "Failed to scroll to cursor position";


### PR DESCRIPTION
This one's pretty self-explanatory, but [here](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes)'s the clippy lint which suggests this change. I suppose `&str` could be removed as well (and clippy suggests this), but since explicit type definitions are more of a preference, I didn't change that part. The warning it presents goes away without removing the type definition.

Hope I'm not bothering you with my multiple separate PR's :smile:. They just seemed too different to do in one PR and some were more of an opinion piece.