### PR TITLE
macOS installation only takes single command

### DIFF
--- a/documentation/pages/installation.md
+++ b/documentation/pages/installation.md
@@ -23,7 +23,7 @@ makepkg -isr
 Available via [Homebrew](https://brew.sh):
 
 ```bash
-brew tap jmacdonald/amp && brew install amp
+brew install jmacdonald/amp/amp
 ```
 
 ## Manual installation


### PR DESCRIPTION
Super straight forward. Homebrew will tap automatically if you have no already “tapped” previously. Just a small quality of life thing.