### PR TITLE
Fix a few crashes on terminal resizing.

### DIFF
--- a/src/presenters/modes/normal.rs
+++ b/src/presenters/modes/normal.rs
@@ -45,8 +45,8 @@ pub fn display(workspace: &mut Workspace, view: &mut View, repo: &Option<Reposit
 
         for (line_no, line) in content.iter().enumerate() {
             let position = Position{
-                line: presenter.height() / 2 + line_no - vertical_offset,
-                offset: presenter.width() / 2 - line.chars().count() / 2
+                line: (presenter.height() / 2 + line_no).saturating_sub(vertical_offset),
+                offset: (presenter.width() / 2).saturating_sub(line.chars().count() / 2)
             };
 
             presenter.print(&position, Style::Default, Colors::Default, line);

--- a/src/view/buffer/renderer.rs
+++ b/src/view/buffer/renderer.rs
@@ -209,7 +209,7 @@ impl<'a, 'p> BufferRenderer<'a, 'p> {
     }
 
     fn after_visible_content(&self) -> bool {
-        self.screen_position.line >= self.terminal.height().saturating_sub(1)
+        self.screen_position.line >= (self.terminal.height() - 1)
     }
 
     fn inside_visible_content(&mut self) -> bool {

--- a/src/view/presenter.rs
+++ b/src/view/presenter.rs
@@ -101,7 +101,7 @@ impl<'p> Presenter<'p> {
                 2 => {
                     if index == entries.len() - 1 {
                         // Expand the last element to fill the remaining width.
-                        element.content.pad_to_width(self.view.terminal.width() - offset)
+                        element.content.pad_to_width(self.view.terminal.width().saturating_sub(offset))
                     } else {
                         element.content.clone()
                     }
@@ -109,7 +109,8 @@ impl<'p> Presenter<'p> {
                 _ => {
                     if index == entries.len() - 2 {
                         // Before-last element extends to fill unused space.
-                        element.content.pad_to_width(self.view.terminal.width() - offset - entries[index+1].content.len())
+                        let space = offset + entries[index+1].content.len();
+                        element.content.pad_to_width(self.view.terminal.width().saturating_sub(space))
                     } else {
                         element.content.clone()
                     }

--- a/src/view/terminal/mod.rs
+++ b/src/view/terminal/mod.rs
@@ -20,6 +20,9 @@ pub use self::termion_terminal::TermionTerminal;
 #[cfg(any(test, feature = "bench"))]
 pub use self::test_terminal::TestTerminal;
 
+const MIN_WIDTH: usize = 10;
+const MIN_HEIGHT: usize = 10;
+
 pub trait Terminal {
     fn listen(&self) -> Option<Event>;
     fn clear(&self);

--- a/src/view/terminal/termion_terminal.rs
+++ b/src/view/terminal/termion_terminal.rs
@@ -202,13 +202,13 @@ impl Terminal for TermionTerminal {
     fn width(&self) -> usize {
         let (width, _) = terminal_size();
 
-        width
+        width.max(super::MIN_WIDTH)
     }
 
     fn height(&self) -> usize {
         let (_, height) = terminal_size();
 
-        height
+        height.max(super::MIN_HEIGHT)
     }
 
     fn set_cursor(&self, position: Option<Position>) {

--- a/src/view/terminal/test_terminal.rs
+++ b/src/view/terminal/test_terminal.rs
@@ -80,8 +80,8 @@ impl Terminal for TestTerminal {
         }
     }
     fn present(&self) { }
-    fn width(&self) -> usize { 10 }
-    fn height(&self) -> usize { 10 }
+    fn width(&self) -> usize { WIDTH }
+    fn height(&self) -> usize { HEIGHT }
     fn set_cursor(&self, position: Option<Position>) {
         let mut cursor = self.cursor.lock().unwrap();
         *cursor = position;
@@ -96,7 +96,7 @@ impl Terminal for TestTerminal {
 
         for (i, c) in string_content.chars().enumerate() {
             // Ignore characters beyond visible width.
-            if i+position.offset >= 10 { break; }
+            if i+position.offset >= WIDTH { break; }
 
             data[position.line][i+position.offset] = Some((c, colors));
         }


### PR DESCRIPTION
This resolves #93. Underlying issue were some overflowing subtractions, which would cause panics in debug mode and OOM-situation in release mode, due to trying to allocate a huge amount of memory. 

I hope I found all possible spots where the assumption that the terminal width/height is at least 1 is made.