### PR TITLE
Add command to comment out a selection of text

### DIFF
--- a/documentation/pages/configuration.md
+++ b/documentation/pages/configuration.md
@@ -80,6 +80,17 @@ types:
     soft_tabs: false
 ```
 
+### Line Commenting
+```yaml
+types:
+  rs:
+    line_comment_prefix: //
+```
+
+This can be used to set the character (sequence) used by the `buffer::toggle_line_comment`
+command for adding (or removing) single-line comments on a per-extension or per-file basis.
+An additional whitespace character will also be inserted between prefix and line content.
+
 ## Key Bindings
 
 In Amp, key bindings are simple key/command associations, scoped to a specific mode. You can define custom key bindings by defining a keymap in your preferences file:

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -1766,4 +1766,188 @@ mod tests {
         app.workspace.next_buffer();
         assert_eq!(app.workspace.current_buffer().unwrap().data(), "two");
     }
+
+    #[test]
+    fn toggle_line_comment_add_single_in_normal_mode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\tamp\n\teditor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 1
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\t// amp\n\teditor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 0, offset: 1 });
+    }
+
+    #[test]
+    fn toggle_line_comment_add_multiple_in_select_line_mode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\tamp\n\t\teditor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 1,
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        commands::application::switch_to_select_line_mode(&mut app).unwrap();
+        app.workspace.current_buffer().unwrap().cursor.move_to(Position {
+            line: 1,
+            offset: 1,
+        });
+
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\t// amp\n\t// \teditor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 1, offset: 1 });
+    }
+
+    #[test]
+    fn toggle_line_comment_remove_single_in_normal_mode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\t// amp\n\teditor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 1,
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\tamp\n\teditor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 0, offset: 1 });
+    }
+
+    #[test]
+    fn toggle_line_comment_remove_multiple_in_select_line_mode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\t// amp\n\t// \teditor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 1,
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        commands::application::switch_to_select_line_mode(&mut app).unwrap();
+        app.workspace.current_buffer().unwrap().cursor.move_to(Position {
+            line: 1,
+            offset: 1,
+        });
+
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\tamp\n\t\teditor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 1, offset: 1 });
+    }
+
+    #[test]
+    fn toggle_line_comment_remove_multiple_with_unequal_indent_in_select_line_mode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\t// amp\n\t\t// editor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 1,
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        commands::application::switch_to_select_line_mode(&mut app).unwrap();
+        app.workspace.current_buffer().unwrap().cursor.move_to(Position {
+            line: 1,
+            offset: 1,
+        });
+
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\tamp\n\t\teditor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 1, offset: 1 });
+    }
+
+    #[test]
+    fn toggle_line_comment_add_correctly_preserves_empty_lines() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\tamp\n\n\teditor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 0,
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        commands::application::switch_to_select_line_mode(&mut app).unwrap();
+        app.workspace.current_buffer().unwrap().cursor.move_to(Position {
+            line: 2,
+            offset: 0,
+        });
+
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\t// amp\n\n\t// editor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 2, offset: 0 });
+    }
+
+    #[test]
+    fn toggle_line_comment_remove_correctly_preserves_empty_lines() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("\t// amp\n\n\t// editor\n");
+        buffer.cursor.move_to(Position {
+            line: 0,
+            offset: 0,
+        });
+        buffer.path = Some("test.rs".into());
+
+        // Now that we've set up the buffer, add it
+        // to the application and call the command.
+        app.workspace.add_buffer(buffer);
+        commands::application::switch_to_select_line_mode(&mut app).unwrap();
+        app.workspace.current_buffer().unwrap().cursor.move_to(Position {
+            line: 2,
+            offset: 0,
+        });
+
+        super::toggle_line_comment(&mut app).unwrap();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "\tamp\n\n\teditor\n");
+        assert_eq!(app.workspace.current_buffer().unwrap().cursor.position,
+                   Position { line: 2, offset: 0 });
+    }
 }

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -468,6 +468,102 @@ pub fn outdent_line(app: &mut Application) -> Result {
     Ok(())
 }
 
+pub fn toggle_line_comment(app: &mut Application) -> Result {
+    let buffer = app.workspace.current_buffer().ok_or(BUFFER_MISSING)?;
+    let original_cursor = *buffer.cursor.clone();
+
+    let comment_prefix = {
+        let path = buffer.path.as_ref().ok_or(BUFFER_PATH_MISSING)?;
+        let prefix = app.preferences.borrow().line_comment_prefix(path)
+            .ok_or("No line comment prefix for the current buffer")?;
+
+        prefix + " " // implicitly add trailing space
+    };
+
+    // Get the range of lines we'll comment based on
+    // either the current selection or cursor line.
+    let line_numbers = match app.mode {
+        Mode::SelectLine(ref mode) => {
+            if mode.anchor >= buffer.cursor.line {
+                buffer.cursor.line..mode.anchor + 1
+            } else {
+                mode.anchor..buffer.cursor.line + 1
+            }
+        }
+        _ => buffer.cursor.line..buffer.cursor.line + 1,
+    };
+
+    let buffer_range = Range::new(
+        Position { line: line_numbers.start, offset: 0 },
+        Position { line: line_numbers.end, offset: 0 }
+    );
+
+    let buffer_range_content = buffer.read(&buffer_range).ok_or(CURRENT_LINE_MISSING)?;
+
+    // Produce a collection of (<line number>, <line content>) tuples, but only for
+    // non-empty lines.
+    let lines: Vec<(usize, &str)> = line_numbers
+        .zip(buffer_range_content.split("\n"))     // produces (<line number>, <line content>)
+        .filter(|(_, line)| line.trim().len() > 0) // filter out any empty (non-whitespace-only) lines
+        .collect();
+
+    // We look at all lines to see if they start with `comment_prefix` or not.
+    // If even a single line does not, we need to comment all lines out,
+    // otherwise remove `comment_prefix` on the start of each line.
+    let (toggle, offset) = lines.iter()
+        // Map (<line number>, <line content>) to (<has comment>, <number of spaces at line start>)
+        .map(|(_, line)| {
+            let content = line.trim_start();
+            (content.starts_with(&comment_prefix), line.len() - content.len())
+        })
+        // Now fold it into a single (<comment in or out>, <comment offset>) tuple.
+        // As soon as <has comment> is `false` a single time, <comment in or out>
+        // will result in `false`.
+        .fold((true, usize::MAX), |(folded_toggle, folded_offset), (has_comment, offset)| {
+            (folded_toggle & has_comment, folded_offset.min(offset))
+        });
+
+    // Move to the start of each of the line's content and
+    // insert/remove the comments, as a single operation.
+    buffer.start_operation_group();
+    if !toggle {
+        add_line_comment(buffer, &lines, offset, &comment_prefix);
+    } else {
+        remove_line_comment(buffer, &lines, &comment_prefix);
+    }
+    buffer.end_operation_group();
+
+    // Restore original cursor
+    buffer.cursor.move_to(original_cursor);
+
+    Ok(())
+}
+
+fn add_line_comment(buffer: &mut Buffer, lines: &[(usize, &str)], offset: usize, prefix: &str) {
+    for (line_number, _) in lines {
+        let target = Position { line: *line_number, offset };
+
+        buffer.cursor.move_to(target);
+        buffer.insert(prefix);
+    }
+}
+
+fn remove_line_comment(buffer: &mut Buffer, lines: &[(usize, &str)], prefix: &str) {
+    for (line_number, line) in lines {
+        let start = Position {
+            line: *line_number,
+            offset: line.len() - line.trim_start().len(),
+        };
+
+        let end = Position {
+            line: *line_number,
+            offset: start.offset + prefix.len(),
+        };
+
+        buffer.delete_range(Range::new(start, end));
+    }
+}
+
 pub fn change_token(app: &mut Application) -> Result {
     commands::buffer::delete_token(app)?;
     commands::application::switch_to_insert_mode(app)?;

--- a/src/input/key_map/default.yml
+++ b/src/input/key_map/default.yml
@@ -62,6 +62,7 @@ normal:
   ",": view::scroll_up
   ">": buffer::indent_line
   "<": buffer::outdent_line
+  "[": buffer::toggle_line_comment
   "=": git::add
   escape: view::scroll_cursor_to_center
   page_up: view::scroll_up
@@ -265,6 +266,7 @@ select_line:
   ",": view::scroll_up
   ">": buffer::indent_line
   "<": buffer::outdent_line
+  "[": buffer::toggle_line_comment
   page_up: view::scroll_up
   page_down: view::scroll_down
   escape: application::switch_to_normal_mode

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -7,7 +7,6 @@ mod preferences;
 pub use self::clipboard::ClipboardContent;
 pub use self::event::Event;
 pub use self::preferences::Preferences;
-pub use self::preferences::THEME_DEFAULT;
 
 use self::clipboard::Clipboard;
 use self::modes::*;

--- a/src/models/application/preferences/default.yml
+++ b/src/models/application/preferences/default.yml
@@ -7,3 +7,39 @@ line_wrapping: true
 open_mode:
   exclusions:
     - "**/.git"
+
+types:
+  rs:
+    line_comment_prefix: //
+  c:
+    line_comment_prefix: //
+  cc:
+    line_comment_prefix: //
+  cpp:
+    line_comment_prefix: //
+  cxx:
+    line_comment_prefix: //
+  cmake:
+    line_comment_prefix: '#'
+  go:
+    line_comment_prefix: //
+  js:
+    line_comment_prefix: //
+  lua:
+    line_comment_prefix: --
+  Makefile:
+    line_comment_prefix: '#'
+  py:
+    line_comment_prefix: '#'
+  sh:
+    line_comment_prefix: '#'
+  swift:
+    line_comment_prefix: //
+  tex:
+    line_comment_prefix: '%'
+  toml:
+    line_comment_prefix: '#'
+  yaml:
+    line_comment_prefix: '#'
+  yml:
+    line_comment_prefix: '#'

--- a/src/models/application/preferences/default.yml
+++ b/src/models/application/preferences/default.yml
@@ -1,0 +1,9 @@
+theme: solarized_dark
+tab_width: 2
+soft_tabs: true
+line_length_guide: 80
+line_wrapping: true
+
+open_mode:
+  exclusions:
+    - "**/.git"

--- a/src/models/application/preferences/mod.rs
+++ b/src/models/application/preferences/mod.rs
@@ -15,17 +15,14 @@ const APP_INFO: AppInfo = AppInfo {
     author: "Jordan MacDonald",
 };
 const FILE_NAME: &str = "config.yml";
-const LINE_LENGTH_GUIDE_DEFAULT: usize = 80;
 const LINE_LENGTH_GUIDE_KEY: &str = "line_length_guide";
-const LINE_WRAPPING_DEFAULT: bool = true;
 const LINE_WRAPPING_KEY: &str = "line_wrapping";
+const OPEN_MODE_KEY: &str = "open_mode";
+const OPEN_MODE_EXCLUSIONS_KEY: &str = "exclusions";
 const SEARCH_SELECT_KEY: &str = "search_select";
-const SOFT_TABS_DEFAULT: bool = true;
 const SOFT_TABS_KEY: &str = "soft_tabs";
 const SYNTAX_PATH: &str = "syntaxes";
-const TAB_WIDTH_DEFAULT: usize = 2;
 const TAB_WIDTH_KEY: &str = "tab_width";
-pub const THEME_DEFAULT: &str = "solarized_dark";
 const THEME_KEY: &str = "theme";
 const THEME_PATH: &str = "themes";
 const TYPES_KEY: &str = "types";
@@ -34,6 +31,7 @@ const TYPES_KEY: &str = "types";
 /// Values are immutable once loaded, with the exception of those that provide
 /// expicit setter methods (e.g. `theme`).
 pub struct Preferences {
+    default: Yaml,
     data: Option<Yaml>,
     keymap: KeyMap,
     theme: Option<String>,
@@ -43,6 +41,7 @@ impl Preferences {
     /// Builds a new in-memory instance with default values.
     pub fn new(data: Option<Yaml>) -> Preferences {
         Preferences {
+            default: load_default_document().expect("Failed to load default preferences!"),
             data,
             keymap: KeyMap::default().expect("Failed to load default keymap!"),
             theme: None
@@ -51,21 +50,24 @@ impl Preferences {
 
     /// Loads preferences from disk, returning any filesystem or parse errors.
     pub fn load() -> Result<Preferences> {
+        let default = load_default_document()?;
         let data = load_document()?;
         let keymap = load_keymap(
             data.as_ref().and_then(|data| data["keymap"].as_hash())
         )?;
 
-        Ok(Preferences { data, keymap, theme: None })
+        Ok(Preferences { default, data, keymap, theme: None })
     }
 
     /// Reloads all user preferences from disk and merges them with defaults.
     pub fn reload(&mut self) -> Result<()> {
+        let default = load_default_document()?;
         let data = load_document()?;
         let keymap = load_keymap(
             data.as_ref().and_then(|data| data["keymap"].as_hash())
         )?;
 
+        self.default = default;
         self.data = data;
         self.keymap = keymap;
         self.theme = None;
@@ -123,7 +125,9 @@ impl Preferences {
                       } else {
                           None
                       })
-            .unwrap_or(THEME_DEFAULT)
+            .unwrap_or_else(|| {
+                self.default[THEME_KEY].as_str().expect("Couldn't find default theme name!")
+            })
     }
 
     /// Returns the theme path, making sure the directory exists.
@@ -153,7 +157,10 @@ impl Preferences {
 
                 None
             })
-            .unwrap_or(TAB_WIDTH_DEFAULT)
+            .unwrap_or_else(|| {
+                self.default[TAB_WIDTH_KEY].as_i64()
+                    .expect("Couldn't find default tab width setting!") as usize
+            })
     }
 
     pub fn search_select_config(&self) -> SearchSelectConfig {
@@ -182,7 +189,10 @@ impl Preferences {
 
                 None
             })
-            .unwrap_or(SOFT_TABS_DEFAULT)
+            .unwrap_or_else(|| {
+                self.default[SOFT_TABS_KEY].as_bool()
+                    .expect("Couldn't find default soft tabs setting!")
+            })
     }
 
     pub fn line_length_guide(&self) -> Option<usize> {
@@ -191,14 +201,18 @@ impl Preferences {
             .and_then(|data| match data[LINE_LENGTH_GUIDE_KEY] {
                           Yaml::Integer(line_length) => Some(line_length as usize),
                           Yaml::Boolean(line_length_guide) => {
+                              let default = self.default[LINE_LENGTH_GUIDE_KEY].as_i64()
+                                  .expect("Couldn't find default line length guide setting!");
+
                               if line_length_guide {
-                                  Some(LINE_LENGTH_GUIDE_DEFAULT)
+                                  Some(default as usize)
                               } else {
                                   None
                               }
                           }
                           _ => None,
                       })
+
     }
 
     pub fn line_wrapping(&self) -> bool {
@@ -209,7 +223,10 @@ impl Preferences {
                       } else {
                           None
                       })
-            .unwrap_or(LINE_WRAPPING_DEFAULT)
+            .unwrap_or_else(|| {
+                self.default[LINE_WRAPPING_KEY].as_bool()
+                    .expect("Couldn't find default line wrapping setting!")
+            })
     }
 
     pub fn tab_content(&self, path: Option<&PathBuf>) -> String {
@@ -221,7 +238,11 @@ impl Preferences {
     }
 
     pub fn open_mode_exclusions(&self) -> Result<Option<Vec<ExclusionPattern>>> {
-        if let Some(exclusion_data) = self.data.as_ref().map(|data| &data["open_mode"]["exclusions"]) {
+        let exclusion_data = self.data
+            .as_ref()
+            .map(|data| &data[OPEN_MODE_KEY][OPEN_MODE_EXCLUSIONS_KEY]);
+
+        if let Some(exclusion_data) = exclusion_data {
             match *exclusion_data {
                 Yaml::Array(ref exclusions) => {
                     open::exclusions::parse(exclusions)
@@ -229,12 +250,21 @@ impl Preferences {
                         .map(Some)
                 },
                 Yaml::Boolean(_) => Ok(None),
-                _ => default_open_mode_exclusions(), // Preference is unset or invalid YAML
+                _ => self.default_open_mode_exclusions(),
             }
         } else {
-            // No user preference data was provided.
-            default_open_mode_exclusions()
+            self.default_open_mode_exclusions()
         }
+    }
+
+    fn default_open_mode_exclusions(&self) -> Result<Option<Vec<ExclusionPattern>>> {
+        let exclusions = self.default[OPEN_MODE_KEY][OPEN_MODE_EXCLUSIONS_KEY]
+            .as_vec()
+            .chain_err(|| "Couldn't find default open mode exclusions settings!")?;
+
+        open::exclusions::parse(exclusions)
+            .chain_err(|| "Failed to parse default open mode exclusions")
+            .map(Some)
     }
 }
 
@@ -264,6 +294,13 @@ fn load_document() -> Result<Option<Yaml>> {
     Ok(parsed_data.into_iter().nth(0))
 }
 
+fn load_default_document() -> Result<Yaml> {
+    YamlLoader::load_from_str(include_str!("default.yml"))
+        .chain_err(|| "Couldn't parse default config file")?
+        .into_iter().nth(0)
+        .chain_err(|| "No default preferences document found")
+}
+
 /// Loads default keymaps, merging in the provided overrides.
 fn load_keymap(keymap_overrides: Option<&Hash>) -> Result<KeyMap> {
     let mut keymap = KeyMap::default()?;
@@ -283,18 +320,12 @@ fn path_extension(path: Option<&PathBuf>) -> Option<&str> {
         .and_then(|e| e.to_str())
 }
 
-fn default_open_mode_exclusions() -> Result<Option<Vec<ExclusionPattern>>> {
-    let default_pattern = ExclusionPattern::new("**/.git")
-        .chain_err(|| "Failed to parse default git directory exclusion pattern")?;
-    Ok(Some(vec![default_pattern]))
-}
-
 #[cfg(test)]
 mod tests {
     use super::{ExclusionPattern, Preferences, YamlLoader};
     use std::path::PathBuf;
     use crate::input::KeyMap;
-    use crate::yaml::yaml::Hash;
+    use crate::yaml::yaml::{Hash, Yaml};
 
     #[test]
     fn preferences_returns_user_defined_theme_name() {
@@ -310,6 +341,13 @@ mod tests {
         preferences.set_theme("new_in_memory_theme");
 
         assert_eq!(preferences.theme(), "new_in_memory_theme");
+    }
+
+    #[test]
+    fn preferences_returns_default_theme_when_user_defined_data_not_found() {
+        let preferences = Preferences::new(None);
+
+        assert_eq!(preferences.theme(), "solarized_dark");
     }
 
     #[test]
@@ -340,6 +378,13 @@ mod tests {
     }
 
     #[test]
+    fn preferences_returns_default_tab_width_when_user_defined_data_not_found() {
+        let preferences = Preferences::new(None);
+
+        assert_eq!(preferences.tab_width(None), 2);
+    }
+
+    #[test]
     fn soft_tabs_returns_user_defined_data() {
         let data = YamlLoader::load_from_str("soft_tabs: false").unwrap();
         let preferences = Preferences::new(data.into_iter().nth(0));
@@ -361,6 +406,13 @@ mod tests {
         let preferences = Preferences::new(data.into_iter().nth(0));
 
         assert_eq!(preferences.soft_tabs(Some(PathBuf::from("preferences.rs")).as_ref()), false);
+    }
+
+    #[test]
+    fn preferences_returns_default_soft_tabs_when_user_defined_data_not_found() {
+        let preferences = Preferences::new(None);
+
+        assert_eq!(preferences.soft_tabs(None), true);
     }
 
     #[test]
@@ -401,6 +453,13 @@ mod tests {
         let preferences = Preferences::new(data.into_iter().nth(0));
 
         assert_eq!(preferences.line_wrapping(), false);
+    }
+
+    #[test]
+    fn preferences_returns_default_line_wrapping_when_user_defined_data_not_found() {
+        let preferences = Preferences::new(None);
+
+        assert_eq!(preferences.line_wrapping(), true);
     }
 
     #[test]
@@ -483,7 +542,7 @@ mod tests {
 
         // Reload preferences and verify that we're no longer using the in-memory theme.
         preferences.reload().unwrap();
-        assert_eq!(preferences.theme(), super::THEME_DEFAULT);
+        assert_eq!(preferences.theme(), "solarized_dark");
     }
 
     #[test]
@@ -494,7 +553,8 @@ mod tests {
         }
 
         // Build a preferences instance with an empty keymap.
-        let mut preferences = Preferences{
+        let mut preferences = Preferences {
+            default: Yaml::Null,
             data: None,
             keymap: KeyMap::from(&Hash::new()).unwrap(),
             theme: None

--- a/src/view/presenter.rs
+++ b/src/view/presenter.rs
@@ -1,5 +1,4 @@
 use crate::errors::*;
-use crate::models::application;
 use crate::view::buffer::{BufferRenderer, LexemeMapper};
 use crate::view::color::{ColorMap, Colors};
 use crate::view::StatusLineData;
@@ -26,7 +25,6 @@ impl<'p> Presenter<'p> {
             let theme_name = preferences.theme();
             let theme = view.theme_set.themes
                 .get(theme_name)
-                .or_else(|| view.theme_set.themes.get(application::THEME_DEFAULT))
                 .ok_or_else(|| format!("Couldn't find \"{}\" theme", theme_name))?;
             theme.clone()
         };


### PR DESCRIPTION
[Closes #100]

Hi!

This implements the `buffer::toggle_line_comment` for normal and select_line mode.
It either:
- Comments the selected lines out if any of the lines are not yet prefixed by the appriopriate comment indicator.
- Remove the comment prefix from any line applicable if all selected lines are already prefixed by the comment indicator.

I'm really used to that functionality to quickly comment in/out something, so I though I'd implement this. This works only for languages which have single-line comments. We could extend that to block comments, but I don't think that is much of a priority (at least for me).

I made [a small gif](https://giphy.com/gifs/ZiOh0JIcaDwtPjX5cl/html5) on how this functionality looks.

~~How a comment starts is defined in a Hashmap, based on the syntax scope of the buffer. I already added quite a few languages, I tried to pick the most likely-to-be-used. We can extend that list easily in the future as needed.
**Question:** Should there be a way for users to define their own entries in their preferences file? Could be useful I guess. 😅~~

Also, for now I assigned the command to <kbd>[</kbd>. I can of course happily change that if you want.