### PR TITLE
Add `syntax` configuration option for applying custom syntax assocations.

### DIFF
--- a/documentation/pages/configuration.md
+++ b/documentation/pages/configuration.md
@@ -154,7 +154,15 @@ Most popular formats and languages have syntax highlighting and symbol support o
 
 ### Manually Picking a Definition
 
-It's possible Amp has a syntax definition for the current file, but it's not being applied because it doesn't recognize the current filename or extension as having been associated with the definition. You can explicitly apply a definition by pressing `#` to enter syntax mode, and searching by the language/format name. Unfortunately, as of this writing, this selection isn't persistent; you'll need to re-apply it every time you open the file.
+It's possible Amp has a syntax definition for the current file, but it's not being applied because it doesn't recognize the current filename or extension as having been associated with the definition. You can explicitly apply a definition by pressing `#` to enter syntax mode, and searching by the language/format name.
+
+To make this syntax selection permanent, you can specify it in your preferences file:
+
+```yaml
+types:
+  rs:
+    syntax: Rust
+```
 
 ### Adding a New Definition
 

--- a/src/models/application/preferences/mod.rs
+++ b/src/models/application/preferences/mod.rs
@@ -357,7 +357,7 @@ fn path_extension(path: Option<&PathBuf>) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::{ExclusionPattern, Preferences, YamlLoader};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use crate::input::KeyMap;
     use crate::yaml::yaml::{Hash, Yaml};
 
@@ -455,6 +455,42 @@ mod tests {
         let preferences = Preferences::new(data.into_iter().nth(0));
 
         assert_eq!(preferences.soft_tabs(Some(PathBuf::from("Makefile")).as_ref()), false);
+    }
+
+    #[test]
+    fn syntax_definition_name_returns_user_defined_syntax_by_extension_for_full_filename() {
+        let data = YamlLoader::load_from_str("types:\n  xyz:\n    syntax: Rust").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.syntax_definition_name(&Path::new("test.xyz")),
+                   Some("Rust".to_owned()));
+    }
+
+    #[test]
+    fn syntax_definition_name_returns_user_defined_syntax_by_extension_for_deep_filename() {
+        let data = YamlLoader::load_from_str("types:\n  xyz:\n    syntax: Rust").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.syntax_definition_name(&Path::new("src/test.xyz")),
+                   Some("Rust".to_owned()));
+    }
+
+    #[test]
+    fn syntax_definition_name_returns_user_defined_syntax_for_full_filename_without_extension() {
+        let data = YamlLoader::load_from_str("types:\n  Makefile:\n    syntax: Makefile").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.syntax_definition_name(&Path::new("Makefile")),
+                   Some("Makefile".to_owned()));
+    }
+
+    #[test]
+    fn syntax_definition_name_returns_user_defined_syntax_for_full_filename_with_extension() {
+        let data = YamlLoader::load_from_str("types:\n  Makefile.lib:\n    syntax: Makefile").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.syntax_definition_name(&Path::new("Makefile.lib")),
+                   Some("Makefile".to_owned()));
     }
 
     #[test]

--- a/src/models/application/preferences/mod.rs
+++ b/src/models/application/preferences/mod.rs
@@ -485,6 +485,15 @@ mod tests {
     }
 
     #[test]
+    fn syntax_definition_name_returns_user_defined_syntax_for_full_deep_filename() {
+        let data = YamlLoader::load_from_str("types:\n  Makefile:\n    syntax: Makefile").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.syntax_definition_name(&Path::new("src/Makefile")),
+                   Some("Makefile".to_owned()));
+    }
+
+    #[test]
     fn syntax_definition_name_returns_user_defined_syntax_for_full_filename_with_extension() {
         let data = YamlLoader::load_from_str("types:\n  Makefile.lib:\n    syntax: Makefile").unwrap();
         let preferences = Preferences::new(data.into_iter().nth(0));


### PR DESCRIPTION
This adds a new type-specific configuration option for applying custom syntax selections permanently.

It's a small feature and definitely something I noticed in the last few months would be useful to have.
