### PR TITLE
Allow specifying multiple line length guides.

### DIFF
--- a/src/view/buffer/renderer.rs
+++ b/src/view/buffer/renderer.rs
@@ -76,10 +76,10 @@ impl<'a, 'p> BufferRenderer<'a, 'p> {
 
     fn print_rest_of_line(&mut self) {
         let on_cursor_line = self.on_cursor_line();
-        let guide_offset = self.length_guide_offset();
+        let guide_offsets = self.length_guide_offsets();
 
         for offset in self.screen_position.offset..self.terminal.width() {
-            let colors = if on_cursor_line || guide_offset.map(|go| go == offset).unwrap_or(false) {
+            let colors = if on_cursor_line || guide_offsets.contains(&offset) {
                 Colors::Focused
             } else {
                 Colors::Default
@@ -92,8 +92,10 @@ impl<'a, 'p> BufferRenderer<'a, 'p> {
         }
     }
 
-    fn length_guide_offset(&self) -> Option<usize> {
-        self.preferences.line_length_guide().map(|offset| self.gutter_width + offset)
+    fn length_guide_offsets(&self) -> Vec<usize> {
+        self.preferences.line_length_guides().into_iter()
+            .map(|offset| self.gutter_width + offset)
+            .collect()
     }
 
     fn advance_to_next_line(&mut self) {


### PR DESCRIPTION
Hi!

Another small PR. This time implementing support for multiple line rulers.
It's a small convenience feature without changing any current behaviour.

I've also been running this as part of my amp build for several months now.

[ One thought: Would it be worth to change `line_length_guides()` so to return a `SmallVec` with e.g. 4/6/8 elements instead of a full-blown `Vec`? ]