### PR TITLE
Text Reflowing/Justification

### DIFF
--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -9,26 +9,13 @@ pub fn delete(app: &mut Application) -> Result {
     if app.workspace.current_buffer().is_none() {
         bail!(BUFFER_MISSING);
     }
-    let buffer = app.workspace.current_buffer().unwrap();
-
     match app.mode {
-        Mode::Select(ref select_mode) => {
-            let cursor_position = *buffer.cursor.clone();
-            let delete_range = Range::new(cursor_position, select_mode.anchor);
+        Mode::Select(_) | Mode::SelectLine(_) | Mode::Search(_) => {
+            let delete_range = range_from(app);
+            let buffer = app.workspace.current_buffer().unwrap();
+
             buffer.delete_range(delete_range.clone());
             buffer.cursor.move_to(delete_range.start());
-        }
-        Mode::SelectLine(ref mode) => {
-            let delete_range = mode.to_range(&*buffer.cursor);
-            buffer.delete_range(delete_range.clone());
-            buffer.cursor.move_to(delete_range.start());
-        }
-        Mode::Search(ref mode) => {
-            let selection = mode.results
-                .as_ref()
-                .and_then(|r| r.selection())
-                .ok_or("Can't delete in search mode without a selected result")?;
-            buffer.delete_range(selection.clone());
         }
         _ => bail!("Can't delete selections outside of select mode"),
     };

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -46,10 +46,7 @@ pub fn justify(app: &mut Application) -> Result {
         buffer.insert(
             &justify_string(
                 &text,
-                match app.preferences.borrow().line_length_guide() {
-                    Some(l) => l,
-                    None => 80,
-                },
+                app.preferences.borrow().line_length_guide().unwrap_or(80),
                 app.preferences.borrow().line_comment_prefix().unwrap_or(""),
             )
         );

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -149,7 +149,7 @@ fn range_from(app: &mut Application) -> Range {
 /// Wrap a string at a given maximum length (generally 80 characters). If the
 /// line begins with a comment (matches potential_prefix), the text is wrapped
 /// around it.
-fn justify_string(text: &String, max_len: usize, potential_prefix: Regex) -> String {
+fn justify_string(text: &str, max_len: usize, potential_prefix: Regex) -> String {
     let mut justified = String::with_capacity(text.len());
     for paragraph in text.split("\n\n") {
         let mut paragraph = paragraph.split_whitespace().peekable();

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -50,7 +50,7 @@ pub fn justify(app: &mut Application) -> Result {
                     Some(l) => l,
                     None => 80,
                 },
-                Regex::new(r"#|//|/\*|///").unwrap(),
+                app.preferences.borrow().line_comment_prefix().unwrap_or(""),
             )
         );
     }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -23,6 +23,21 @@ pub fn delete(app: &mut Application) -> Result {
     Ok(())
 }
 
+pub fn justify(app: &mut Application) -> Result {
+    if app.workspace.current_buffer().is_none() {
+        bail!(BUFFER_MISSING);
+    }
+
+    let range = match app.mode {
+        Mode::Select(_) | Mode::SelectLine(_) | Mode::Search(_) => {
+            range_from(app);
+        }
+        _ => bail!("Can't justify without selection"),
+    };
+
+    Ok(())
+}
+
 pub fn copy_and_delete(app: &mut Application) -> Result {
     let _ = copy_to_clipboard(app);
     delete(app)

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -149,7 +149,7 @@ fn justify_string(text: &String) -> String {
 
         while paragraph.peek().is_some() {
             for word in (&mut paragraph).take_while(|s| {
-                len += s.len();
+                len += s.len() + 1;
                 if len > 80 {
                     len = s.len();
                     false

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -41,7 +41,15 @@ pub fn justify(app: &mut Application) -> Result {
         buffer.delete_range(range.clone());
         buffer.cursor.move_to(range.start());
 
-        buffer.insert(&justify_string(&text));
+        buffer.insert(
+            &justify_string(
+                &text,
+                match app.preferences.borrow().line_length_guide() {
+                    Some(l) => l,
+                    None => 80,
+                }
+            )
+        );
     }
 
     Ok(())
@@ -140,7 +148,7 @@ fn range_from(app: &mut Application) -> Range {
 
 /// Justify a string: for each paragraph, transform it to break off at a character
 /// limit
-fn justify_string(text: &String) -> String {
+fn justify_string(text: &String, max_len: usize) -> String {
     let mut justified = String::new();
     for paragraph in text.split("\n\n") {
         let paragraph = paragraph.split_whitespace();
@@ -148,7 +156,7 @@ fn justify_string(text: &String) -> String {
 
         for word in paragraph {
             len += word.len() + 1;
-            if len > 80 {
+            if len > max_len {
                 len = word.len();
                 justified.push('\n');
             }
@@ -288,7 +296,7 @@ mod tests {
             "\nthis is a very \n long line with inconsistent line \nbreaks, even though it should have breaks.\n"
         );
         assert_eq!(
-            super::justify_string(&text),
+            super::justify_string(&text, 80),
             String::from("this is a very long line with inconsistent line breaks, even though it should \nhave breaks. \n\n")
         );
     }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -144,8 +144,19 @@ fn range_from(app: &mut Application) -> Range {
 fn justify_string(text: &String) -> String {
     let mut justified = String::new();
     for paragraph in text.split("\n\n") {
-        for line in paragraph.split(|c: char| c.is_whitespace()) {
-            justified += line;
+        let mut paragraph = paragraph.split_whitespace().peekable();
+        let mut len = 0;
+
+        while paragraph.peek().is_some() {
+            justified += &((&mut paragraph).take_while(|s| {
+                len += s.len();
+                if len > 80 {
+                    len = s.len();
+                    false
+                } else {
+                    true
+                }
+            }).collect::<String>())[..];
             justified.push('\n');
         }
     }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -148,7 +148,7 @@ fn justify_string(text: &String) -> String {
         let mut len = 0;
 
         while paragraph.peek().is_some() {
-            justified += &((&mut paragraph).take_while(|s| {
+            for word in (&mut paragraph).take_while(|s| {
                 len += s.len();
                 if len > 80 {
                     len = s.len();
@@ -156,7 +156,10 @@ fn justify_string(text: &String) -> String {
                 } else {
                     true
                 }
-            }).collect::<String>())[..];
+            }) {
+                justified += word;
+                justified.push(' ');
+            }
             justified.push('\n');
         }
     }
@@ -282,5 +285,18 @@ mod tests {
             app.workspace.current_buffer().unwrap().data(),
             String::from("amp\nitor\nbuffer")
         )
+    }
+
+    #[test]
+    fn justify_justifies() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("this is a very long line with no breaks, even though it should have breaks.\n");
+        app.workspace.add_buffer(buffer);
+        commands::selection::select_all(&mut app).unwrap();
+        commands::selection::justify(&mut app).unwrap();
+
+        let buffer = app.workspace.current_buffer().unwrap().data();
+        println!("DATA: {}", buffer);
     }
 }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -49,7 +49,8 @@ pub fn justify(app: &mut Application) -> Result {
                 match app.preferences.borrow().line_length_guide() {
                     Some(l) => l,
                     None => 80,
-                }
+                },
+                Regex::new(r"#|//|/\*|///").unwrap(),
             )
         );
     }
@@ -148,19 +149,17 @@ fn range_from(app: &mut Application) -> Range {
     }
 }
 
-/// Justify a string: for each paragraph, transform it to break off at a character
-/// limit
-fn justify_string(text: &String, max_len: usize) -> String {
-    let comment_prefix = Regex::new("//|///|#|/\\*").unwrap();
-
+/// Wrap a string at a given maximum length (generally 80 characters). If the
+/// line begins with a comment (matches potential_prefix), the text is wrapped
+/// around it.
+fn justify_string(text: &String, max_len: usize, potential_prefix: Regex) -> String {
     let mut justified = String::new();
     for paragraph in text.split("\n\n") {
         let mut paragraph = paragraph.split_whitespace().peekable();
-        // if the paragraph begins with a prefix
         let prefix;
         let max_len_with_prefix;
         if paragraph.peek().is_some()
-           && comment_prefix.is_match(paragraph.peek().unwrap())
+           && potential_prefix.is_match(paragraph.peek().unwrap())
         {
             prefix = paragraph.next().unwrap().to_owned() + " ";
             max_len_with_prefix = max_len - prefix.len();

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -23,32 +23,6 @@ pub fn delete(app: &mut Application) -> Result {
     Ok(())
 }
 
-/// Get the selected range from an application in a selection mode. *Requires*
-/// that the application has a buffer and is in mode Select, SelectLine, or
-/// Search.
-fn range_from(app: &mut Application) -> Range {
-    let buffer = app.workspace.current_buffer();
-    let buffer = buffer.unwrap();
-
-    match app.mode {
-        Mode::Select(ref select_mode) => {
-            Range::new(*buffer.cursor.clone(), select_mode.anchor)
-        }
-        Mode::SelectLine(ref select_line_mode) => {
-            select_line_mode.to_range(&*buffer.cursor)
-        }
-        Mode::Search(ref mode) => {
-            mode.results
-            .as_ref()
-            .and_then(|r| r.selection())
-            .ok_or("Cannot get selection outside of select mode.")
-            .unwrap()
-            .clone()
-        }
-        _ => panic!("Cannot get selection outside of select mode."),
-    }
-}
-
 pub fn copy_and_delete(app: &mut Application) -> Result {
     let _ = copy_to_clipboard(app);
     delete(app)
@@ -112,6 +86,32 @@ fn copy_to_clipboard(app: &mut Application) -> Result {
     };
 
     Ok(())
+}
+
+/// Get the selected range from an application in a selection mode. *Requires*
+/// that the application has a buffer and is in mode Select, SelectLine, or
+/// Search.
+fn range_from(app: &mut Application) -> Range {
+    let buffer = app.workspace.current_buffer();
+    let buffer = buffer.unwrap();
+
+    match app.mode {
+        Mode::Select(ref select_mode) => {
+            Range::new(*buffer.cursor.clone(), select_mode.anchor)
+        }
+        Mode::SelectLine(ref select_line_mode) => {
+            select_line_mode.to_range(&*buffer.cursor)
+        }
+        Mode::Search(ref mode) => {
+            mode.results
+            .as_ref()
+            .and_then(|r| r.selection())
+            .ok_or("Cannot get selection outside of select mode.")
+            .unwrap()
+            .clone()
+        }
+        _ => panic!("Cannot get selection outside of select mode."),
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -314,4 +314,15 @@ mod tests {
             String::from("this is a very long line with inconsistent line breaks, even though it should \nhave breaks. \n\n")
         );
     }
+
+    #[test]
+    fn justify_justifies_with_comment() {
+        let text = String::from(
+            "\n// this is a very \n long line with inconsistent line \nbreaks, even though it should have breaks.\n"
+        );
+        assert_eq!(
+            super::justify_string(&text, 80, "//"),
+            String::from("// this is a very long line with inconsistent line breaks, even though it \n// should have breaks. \n\n")
+        );
+    }
 }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -151,11 +151,9 @@ fn justify_string(text: &String) -> String {
             if len > 80 {
                 len = word.len();
                 justified.push('\n');
-                justified += word;
-            } else {
-                justified += word;
-                justified.push(' ');
             }
+            justified += word;
+            justified.push(' ');
         }
 
         justified += "\n\n"; // add the paragraph delim
@@ -286,17 +284,12 @@ mod tests {
 
     #[test]
     fn justify_justifies() {
-        let mut app = Application::new(&Vec::new()).unwrap();
-        let mut buffer = Buffer::new();
-        buffer.insert("\nthis is a very \n long line with inconsistent line \nbreaks, even though it should have breaks.\n");
-        app.workspace.add_buffer(buffer);
-        println!("DATA: {}", app.workspace.current_buffer().unwrap().data());
-        commands::selection::select_all(&mut app).unwrap();
-        commands::selection::justify(&mut app).unwrap();
-
+        let text = String::from(
+            "\nthis is a very \n long line with inconsistent line \nbreaks, even though it should have breaks.\n"
+        );
         assert_eq!(
-            app.workspace.current_buffer().unwrap().data(),
-            String::from("this is a very long line with inconsistent line breaks, even though it should\nhave breaks")
+            super::justify_string(&text),
+            String::from("this is a very long line with inconsistent line breaks, even though it should \nhave breaks. \n\n")
         );
     }
 }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -119,8 +119,7 @@ fn copy_to_clipboard(app: &mut Application) -> Result {
 /// that the application has a buffer and is in mode Select, SelectLine, or
 /// Search.
 fn range_from(app: &mut Application) -> std::result::Result<Range, Error> {
-    let buffer = app.workspace.current_buffer();
-    let buffer = buffer.unwrap();
+    let buffer = app.workspace.current_buffer().ok_or(BUFFER_MISSING)?;
 
     Ok(match app.mode {
         Mode::Select(ref select_mode) => {

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -143,7 +143,7 @@ fn range_from(app: &mut Application) -> Range {
 fn justify_string(text: &String) -> String {
     let mut justified = String::new();
     for paragraph in text.split("\n\n") {
-        let mut paragraph = paragraph.split_whitespace().peekable();
+        let paragraph = paragraph.split_whitespace();
         let mut len = 0;
 
         for word in paragraph {

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -13,7 +13,7 @@ pub fn delete(app: &mut Application) -> Result {
     }
     match app.mode {
         Mode::Select(_) | Mode::SelectLine(_) | Mode::Search(_) => {
-            let delete_range = range_from(app);
+            let delete_range = range_from(app)?;
             let buffer = app.workspace.current_buffer().unwrap();
 
             buffer.delete_range(delete_range.clone());
@@ -30,12 +30,7 @@ pub fn justify(app: &mut Application) -> Result {
         bail!(BUFFER_MISSING);
     }
 
-    let range = match app.mode {
-        Mode::Select(_) | Mode::SelectLine(_) | Mode::Search(_) => {
-            range_from(app)
-        }
-        _ => bail!("Can't justify without selection"),
-    };
+    let range = range_from(app)?;
 
     // delete and save the range, then justify that range
     let buffer = app.workspace.current_buffer().unwrap();
@@ -123,11 +118,11 @@ fn copy_to_clipboard(app: &mut Application) -> Result {
 /// Get the selected range from an application in a selection mode. *Requires*
 /// that the application has a buffer and is in mode Select, SelectLine, or
 /// Search.
-fn range_from(app: &mut Application) -> Range {
+fn range_from(app: &mut Application) -> std::result::Result<Range, Error> {
     let buffer = app.workspace.current_buffer();
     let buffer = buffer.unwrap();
 
-    match app.mode {
+    Ok(match app.mode {
         Mode::Select(ref select_mode) => {
             Range::new(*buffer.cursor.clone(), select_mode.anchor)
         }
@@ -143,7 +138,7 @@ fn range_from(app: &mut Application) -> Range {
             .clone()
         }
         _ => bail!("Cannot get selection outside of select mode."),
-    }
+    })
 }
 
 /// Wrap a string at a given maximum length (generally 80 characters). If the

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -150,7 +150,7 @@ fn range_from(app: &mut Application) -> Range {
 /// line begins with a comment (matches potential_prefix), the text is wrapped
 /// around it.
 fn justify_string(text: &String, max_len: usize, potential_prefix: Regex) -> String {
-    let mut justified = String::new();
+    let mut justified = String::with_capacity(text.len());
     for paragraph in text.split("\n\n") {
         let mut paragraph = paragraph.split_whitespace().peekable();
         let prefix;

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -318,7 +318,7 @@ mod tests {
             "\nthis is a very \n long line with inconsistent line \nbreaks, even though it should have breaks.\n"
         );
         assert_eq!(
-            super::justify_string(&text, 80),
+            super::justify_string(&text, 80, super::Regex::new("//").unwrap()),
             String::from("this is a very long line with inconsistent line breaks, even though it should \nhave breaks. \n\n")
         );
     }

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -145,7 +145,7 @@ fn range_from(app: &mut Application) -> Range {
             .unwrap()
             .clone()
         }
-        _ => panic!("Cannot get selection outside of select mode."),
+        _ => bail!("Cannot get selection outside of select mode."),
     }
 }
 

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -157,6 +157,8 @@ fn justify_string(text: &String) -> String {
                 justified.push(' ');
             }
         }
+
+        justified += "\n\n"; // add the paragraph delim
     }
 
     justified

--- a/src/input/key_map/default.yml
+++ b/src/input/key_map/default.yml
@@ -226,6 +226,7 @@ select:
   ctrl-a: selection::select_all
   ctrl-z: application::suspend
   ctrl-c: application::exit
+  a: selection::justify
 
 select_line:
   up: cursor::move_up

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -57,7 +57,10 @@ impl Application {
     /// Initialize an empty application in normal mode with any discovered
     /// repository, and default preferences.
     pub fn new(args: &Vec<String>) -> Result<Application> {
-        let preferences = initialize_preferences();
+        let preferences =
+            Rc::new(RefCell::new(
+                Preferences::load().unwrap_or_else(|_| Preferences::new(None)),
+            ));
 
         let (event_channel, events) = mpsc::channel();
         let mut view = View::new(preferences.clone(), event_channel.clone())?;
@@ -218,12 +221,6 @@ impl Application {
             Mode::Exit => None,
         }
     }
-}
-
-fn initialize_preferences() -> Rc<RefCell<Preferences>> {
-    Rc::new(RefCell::new(
-        Preferences::load().unwrap_or_else(|_| Preferences::new(None)),
-    ))
 }
 
 fn create_workspace(view: &mut View, preferences: &Preferences, args: &Vec<String>) -> Result<Workspace> {

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -54,6 +54,8 @@ pub struct Application {
 }
 
 impl Application {
+    /// Initialize an empty application in normal mode with any discovered
+    /// repository, and default preferences.
     pub fn new(args: &Vec<String>) -> Result<Application> {
         let preferences = initialize_preferences();
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -46,8 +46,14 @@ pub struct View {
 }
 
 impl View {
-    pub fn new(preferences: Rc<RefCell<Preferences>>, event_channel: Sender<Event>) -> Result<View> {
-        let terminal = build_terminal().chain_err(|| "Failed to initialize terminal")?;
+    /// Return a new view. This will initialize the terminal, load the theme,
+    /// and begin to listen for events.
+    pub fn new(
+        preferences: Rc<RefCell<Preferences>>,
+        event_channel: Sender<Event>
+    ) -> Result<View> {
+        let terminal = build_terminal()
+                       .chain_err(|| "Failed to initialize terminal")?;
         let theme_path = preferences.borrow().theme_path()?;
         let theme_set = ThemeLoader::new(theme_path).load()?;
 


### PR DESCRIPTION
This fork introduces 'justification' functionality, where a line may be reformatted from
```
very long paragraph with no linebreaks, exceeding the eighty character line limit of most everywhere
```
to
```
very long paragraph with no linebreaks, exceeding the eighty character line
limit of most everywhere
```
The command will justify around comments, for instance
```
# very long paragraph with no linebreaks, exceeding the eighty character line limit of most everywhere
```
to
```
# very long paragraph with no linebreaks, exceeding the eighty character line
# limit of most everywhere
```
Line length is determined by the line_length_guide property in the preferences, or a hard-coded value of 80 if the guide is not present. Characters that count as a comment (referred to as a prefix in the justify_text function) are determined by a hard-coded regex, as the `line_comment_prefix` option is limited to only one style (and thus would break on, for instance, rustdoc comments).

This addresses #219.