### PR TITLE
Make OS clipboard support optional.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ branches:
 addons:
   apt:
     packages:
-    - libxmu-dev
+    - libxcb-shape0-dev
+    - libxcb-xfixes0-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4623b47d8637fc9d47564583d4cc01eb8c8e34e26b2bf348bf4b036acb657"
+checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
 dependencies = [
  "clipboard-win",
  "objc",
@@ -328,15 +328,6 @@ name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 dependencies = [
  "backtrace",
 ]
@@ -1425,11 +1416,10 @@ dependencies = [
 
 [[package]]
 name = "x11-clipboard"
-version = "0.2.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7374c7699210cca7084ca61d57e09640fc744d1391808cb9ae2fe4ca9bd1df"
+checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
 dependencies = [
- "error-chain 0.11.0",
  "xcb",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,14 @@ syntect = "2.1.0"
 termion = "1.5.1"
 error-chain = "0.12.4"
 unicode-segmentation = "1.0.1"
-clipboard = "0.4.4"
 yaml-rust = ">= 0.4.5"
 smallvec = "0.4.3"
 lazy_static = "1.2.0"
 mio = "0.6"
+
+[dependencies.clipboard]
+version = "0.5.0"
+optional = true
 
 [dependencies.signal-hook]
 version = "0.1.9"
@@ -46,6 +49,9 @@ default-features = false # removes unused openssl dependency
 
 [dev-dependencies]
 criterion = "0.2.0"
+
+[features]
+default = ["clipboard"]
 
 [[bench]]
 name = "draw_buffer"

--- a/documentation/pages/installation.md
+++ b/documentation/pages/installation.md
@@ -31,15 +31,21 @@ brew install amp
 ### Dependencies
 
 * `git`
-* `libxcb` (X11 clipboard support)
+* `libxcb` if building on Linux (X11 clipboard support)
 * `openssl`
 * `zlib`
+
+The dependency on `libxcb` can be avoided by excluding the `clipboard` feature when building Amp, useful for e.g. headless machines.
 
 ### Build dependencies
 
 * `cmake`
 * `rust`
 * `python3` if building on Linux
+
+### Feature flags
+
+* `clipboard`, enabled by default.
 
 ### Building
 
@@ -54,4 +60,10 @@ brew install amp
 
     ```
     cargo install amp
+    ```
+
+    To build and install Amp without any of its optional features:
+
+    ```
+    cargo install --no-default-features amp
     ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ extern crate scribe;
 extern crate signal_hook;
 extern crate syntect;
 extern crate unicode_segmentation;
-extern crate clipboard;
 extern crate yaml_rust as yaml;
 extern crate smallvec;
 

--- a/src/models/application/clipboard/dummy_clipboard.rs
+++ b/src/models/application/clipboard/dummy_clipboard.rs
@@ -1,0 +1,32 @@
+use crate::errors::*;
+use super::ClipboardContent;
+
+// Simple in-app clipboard without any OS interactions.
+pub struct Clipboard {
+    content: ClipboardContent,
+}
+
+impl Default for Clipboard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clipboard {
+    pub fn new() -> Clipboard {
+        Clipboard {
+            content: ClipboardContent::None,
+        }
+    }
+
+    // Returns the in-app clipboard content.
+    pub fn get_content(&mut self) -> &ClipboardContent {
+        &self.content
+    }
+
+    // Updates the in-app clipboard with the specified content.
+    pub fn set_content(&mut self, content: ClipboardContent) -> Result<()> {
+        self.content = content;
+        Ok(())
+    }
+}

--- a/src/models/application/clipboard/mod.rs
+++ b/src/models/application/clipboard/mod.rs
@@ -1,0 +1,22 @@
+#[cfg(not(feature = "clipboard"))]
+mod dummy_clipboard;
+#[cfg(not(feature = "clipboard"))]
+pub use dummy_clipboard::Clipboard;
+
+#[cfg(feature = "clipboard")]
+mod system_clipboard;
+#[cfg(feature = "clipboard")]
+pub use system_clipboard::Clipboard;
+
+/// In-app content can be captured in both regular and full-line selection
+/// modes. This type describes the structure of said content, based on the
+/// context in which it was captured. When OS-level clipboard contents are
+/// used, they are always represented as inline, as we cannot infer block
+/// style without the copy context.
+#[derive(Debug, PartialEq)]
+pub enum ClipboardContent {
+    Inline(String),
+    Block(String),
+    None,
+}
+

--- a/src/models/application/clipboard/system_clipboard.rs
+++ b/src/models/application/clipboard/system_clipboard.rs
@@ -1,17 +1,7 @@
 use crate::errors::*;
-use clipboard::{ClipboardContext, ClipboardProvider};
+use super::ClipboardContent;
 
-/// In-app content can be captured in both regular and full-line selection
-/// modes. This type describes the structure of said content, based on the
-/// context in which it was captured. When OS-level clipboard contents are
-/// used, they are always represented as inline, as we cannot infer block
-/// style without the copy context.
-#[derive(Debug, PartialEq)]
-pub enum ClipboardContent {
-    Inline(String),
-    Block(String),
-    None,
-}
+use clipboard::{ClipboardContext, ClipboardProvider};
 
 /// Qualifies in-app copy/paste content with structural information, and
 /// synchronizes said content with the OS-level clipboard (preferring it


### PR DESCRIPTION
This lets the clipboard support depend on a cargo feature flag, which is enabled by default.
This means no visible change for normal users.

Disabling OS clipboard support can be useful when using Amp on e.g. Linux servers, which normally do not have `libxcb` installed.
Being able to use Amp in embedded or server environment is very useful, not having to use different editors across different machines.

The clipboard selection mechanism in `src/models/application/clipboard/mod.rs ` was the cleanest way I found to do that. We could use the `cfg_if` crate to simplify it a bit, but I don't think it would worth for the few lines introduced by this.

I've also updated the `clipboard` crate, which pulls in a new version of the `x11-clipboard` crate. This in turn now requires `libxcb-xfixes` and `libxcb-shape` to be installed, which required the Travis CI config to be updated. This libraries should be installed on any X11 system out there, so again no visible change.

[ My 2 cents: Travis CI will soon be shutdown, so Amp could/should switch to GitHub actions. I can do that too via a future PR, it shouldn't be much of a hassle. ]