### PR TITLE
Fix Unicode handling in ensure_trailing_newline

### DIFF
--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -790,7 +790,7 @@ pub fn ensure_trailing_newline(app: &mut Application) -> Result {
                 buffer.insert("\n");
                 buffer.cursor.move_to(original_position);
             } else {
-                bail!("Couldn't move to end of buffer");
+                bail!("Couldn't move to the end of the buffer and insert a newline.");
             }
         }
     } else {

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -783,7 +783,7 @@ pub fn ensure_trailing_newline(app: &mut Application) -> Result {
             let original_position = *buffer.cursor;
             let target_position = Position {
                 line: line_no,
-                offset: line.len(),
+                offset: line.chars().count(),
             };
 
             if buffer.cursor.move_to(target_position) {
@@ -794,7 +794,7 @@ pub fn ensure_trailing_newline(app: &mut Application) -> Result {
             }
         }
     } else {
-        buffer.insert("\n"); // Empty buffer
+        buffer.insert('\n'); // Empty buffer
     }
 
     Ok(())
@@ -1275,6 +1275,18 @@ mod tests {
         // Ensure that trailing whitespace is removed.
         assert_eq!(app.workspace.current_buffer().unwrap().data(),
                    "amp\neditor\n");
+    }
+
+    #[test]
+    fn save_adds_newline_with_unicode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+        let mut buffer = Buffer::new();
+        buffer.insert("amp    \n∴ editor ");
+        app.workspace.add_buffer(buffer);
+        super::save(&mut app).ok();
+
+        assert_eq!(app.workspace.current_buffer().unwrap().data(),
+                   "amp\n∴ editor\n");
     }
 
     #[test]


### PR DESCRIPTION
If the last line contains some unicode (I ran into this with `∴` in particular), adding a trailing newline will fail. This patch just uses `line.chars().count()` instead of `line.len()`. This makes the op O(n), but:

+ It's O(n) only with respect to the length of a line.
+ The O(1) solution breaks.