### PR TITLE
group justify command as a single operation

### DIFF
--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -89,7 +89,9 @@ pub fn justify(app: &mut Application) -> Result {
     	None => bail!("Justification requires a line_length_guide."),
     };
 
+    buffer.start_operation_group();
     Reflow::new(&mut buffer, range, limit)?.apply()?;
+    buffer.end_operation_group();
 
     Ok(())
 }


### PR DESCRIPTION
Hey, sorry for the many PRs I've opened. this is just something I noticed and fixed in my build; figured I should submit it upstream! thanks!

---
commit message:
```
Prior to this commit, Amp would treat justification as two seperate
operations, leading to unexpected undo-redo behavior: Amp would first
get rid of the all the text and then replace it with the original
version upon two undos. The expected behavior is to treat the
justification as atomic, and Scribe's provided start/end_operation_group
methods are used to achieve that.
```