### PR TITLE
Allow specifying multiple values for `line_length_guide` in config

### DIFF
--- a/documentation/pages/configuration.md
+++ b/documentation/pages/configuration.md
@@ -44,10 +44,15 @@ See: the infamous tabs vs. spaces debate.
 
 ```yaml
 line_length_guide: 80
+# or
+line_length_guide:
+  - 80
+  - 100
 ```
 
 When set to a positive integer, this renders a background vertical line at the specified offset, to guide line length. When set to `false`, the guide is hidden.
 
+It can also be set to an array, in which case a vertical line is rendered at each specified offset.
 
 ### Line Wrapping
 

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -22,7 +22,7 @@ pub fn save(app: &mut Application) -> Result {
         .path
         .clone(); // clone instead of borrow as we call another command later
 
-    if path.is_some() {
+    if let Some(path) = path {
         // Save the buffer.
         app.workspace
             .current_buffer
@@ -32,7 +32,7 @@ pub fn save(app: &mut Application) -> Result {
             .chain_err(|| BUFFER_SAVE_FAILED)?;
 
         // Run the format command if one is defined.
-        if app.preferences.borrow().format_on_save(&path.unwrap()) {
+        if app.preferences.borrow().format_on_save(&path) {
             format(app)?;
 
             // Save the buffer again. We intentionally save twice because we
@@ -914,7 +914,7 @@ pub fn insert_tab(app: &mut Application) -> Result {
         .ok_or(BUFFER_MISSING)?;
     let tab_content = app.preferences.borrow().tab_content(buffer.path.as_ref());
     let tab_content_width = tab_content.chars().count();
-    buffer.insert(tab_content.clone());
+    buffer.insert(tab_content);
 
     // Move the cursor to the end of the inserted content.
     for _ in 0..tab_content_width {

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -86,9 +86,9 @@ pub fn justify(app: &mut Application) -> Result {
     let range = sel_to_range(app)?;
     let buffer = app.workspace.current_buffer.as_mut().unwrap();
 
-    let limit = match app.preferences.borrow().line_length_guide() {
-        Some(n) => n,
-        None => bail!("Justification requires a line_length_guide."),
+    let limit = match app.preferences.borrow().line_length_guides()[..] {
+        [first, ..] => first,
+        [] => bail!("Justification requires a line_length_guide."),
     };
 
     buffer.start_operation_group();

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -63,7 +63,7 @@ fn copy_to_clipboard(app: &mut Application) -> Result {
             let selected_range = Range::new(cursor_position, select_mode.anchor);
 
             let data = buffer
-                .read(&selected_range.clone())
+                .read(&selected_range)
                 .ok_or("Couldn't read selected data from buffer")?;
             app.clipboard.set_content(ClipboardContent::Inline(data))?;
         }
@@ -72,7 +72,7 @@ fn copy_to_clipboard(app: &mut Application) -> Result {
                 util::inclusive_range(&LineRange::new(mode.anchor, buffer.cursor.line), buffer);
 
             let data = buffer
-                .read(&selected_range.clone())
+                .read(&selected_range)
                 .ok_or("Couldn't read selected data from buffer")?;
             app.clipboard.set_content(ClipboardContent::Block(data))?;
         }

--- a/src/input/key_map/mod.rs
+++ b/src/input/key_map/mod.rs
@@ -66,7 +66,7 @@ impl KeyMap {
         let default_keymap_data = YamlLoader::load_from_str(KeyMap::default_data())
             .chain_err(|| "Couldn't parse default keymap")?
             .into_iter()
-            .nth(0)
+            .next()
             .ok_or("Couldn't locate a document in the default keymap")?;
 
         KeyMap::from(default_keymap_data.as_hash().unwrap())

--- a/src/models/application/clipboard.rs
+++ b/src/models/application/clipboard.rs
@@ -77,8 +77,8 @@ impl Clipboard {
         };
 
         // Update the in-app clipboard if we've found newer content.
-        if new_content.is_some() {
-            self.content = new_content.unwrap();
+        if let Some(new_content) = new_content {
+            self.content = new_content;
         }
 
         &self.content

--- a/src/models/application/preferences/mod.rs
+++ b/src/models/application/preferences/mod.rs
@@ -207,24 +207,29 @@ impl Preferences {
             })
     }
 
-    pub fn line_length_guide(&self) -> Option<usize> {
+    pub fn line_length_guides(&self) -> Vec<usize> {
         self.data
             .as_ref()
-            .and_then(|data| match data[LINE_LENGTH_GUIDE_KEY] {
-                Yaml::Integer(line_length) => Some(line_length as usize),
+            .map(|data| match data[LINE_LENGTH_GUIDE_KEY] {
+                Yaml::Integer(line_length) => vec![line_length as usize],
                 Yaml::Boolean(line_length_guide) => {
                     let default = self.default[LINE_LENGTH_GUIDE_KEY]
                         .as_i64()
                         .expect("Couldn't find default line length guide setting!");
 
                     if line_length_guide {
-                        Some(default as usize)
+                        vec![default as usize]
                     } else {
-                        None
+                        vec![]
                     }
                 }
-                _ => None,
+                Yaml::Array(ref guides) => guides
+                    .iter()
+                    .filter_map(|value| value.as_i64().map(|v| v as usize))
+                    .collect(),
+                _ => vec![],
             })
+            .unwrap_or_default()
     }
 
     pub fn line_wrapping(&self) -> bool {
@@ -584,7 +589,15 @@ mod tests {
         let data = YamlLoader::load_from_str("line_length_guide: 100").unwrap();
         let preferences = Preferences::new(data.into_iter().nth(0));
 
-        assert_eq!(preferences.line_length_guide(), Some(100));
+        assert_eq!(preferences.line_length_guides(), vec![100]);
+    }
+
+    #[test]
+    fn preferences_returns_user_defined_multiple_line_length_guides() {
+        let data = YamlLoader::load_from_str("line_length_guide: [80, 100, 120]").unwrap();
+        let preferences = Preferences::new(data.into_iter().nth(0));
+
+        assert_eq!(preferences.line_length_guides(), vec![80, 100, 120]);
     }
 
     #[test]
@@ -592,7 +605,7 @@ mod tests {
         let data = YamlLoader::load_from_str("line_length_guide: false").unwrap();
         let preferences = Preferences::new(data.into_iter().nth(0));
 
-        assert_eq!(preferences.line_length_guide(), None);
+        assert_eq!(preferences.line_length_guides(), Vec::<usize>::new());
     }
 
     #[test]
@@ -600,7 +613,7 @@ mod tests {
         let data = YamlLoader::load_from_str("line_length_guide: true").unwrap();
         let preferences = Preferences::new(data.into_iter().nth(0));
 
-        assert_eq!(preferences.line_length_guide(), Some(80));
+        assert_eq!(preferences.line_length_guides(), vec![80]);
     }
 
     #[test]

--- a/src/view/buffer/renderer.rs
+++ b/src/view/buffer/renderer.rs
@@ -85,10 +85,10 @@ impl<'a, 'p> BufferRenderer<'a, 'p> {
 
     fn print_rest_of_line(&mut self) {
         let on_cursor_line = self.on_cursor_line();
-        let guide_offset = self.length_guide_offset();
+        let guide_offsets = self.length_guide_offsets();
 
         for offset in self.screen_position.offset..self.terminal.width() {
-            let colors = if on_cursor_line || guide_offset.map(|go| go == offset).unwrap_or(false) {
+            let colors = if on_cursor_line || guide_offsets.contains(&offset) {
                 Colors::Focused
             } else {
                 Colors::Default
@@ -106,10 +106,12 @@ impl<'a, 'p> BufferRenderer<'a, 'p> {
         }
     }
 
-    fn length_guide_offset(&self) -> Option<usize> {
+    fn length_guide_offsets(&self) -> Vec<usize> {
         self.preferences
-            .line_length_guide()
+            .line_length_guides()
+            .into_iter()
             .map(|offset| self.gutter_width + offset)
+            .collect()
     }
 
     fn advance_to_next_line(&mut self) {


### PR DESCRIPTION
Hi,

long time no see :^)

Anyway, had this branch still laying around from #210, so I thought I'd quickly rebase it before it completely rots away.

Preferences now returns a `Vec` instead of an `Option`. As for the configuration itself, it still allows a single value as before, but also an array now. The only change from the previous PR is a change required by the new justify code, but that's pretty trivial. 
 