### PR TITLE
Persistent modes

### DIFF
--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -144,10 +144,17 @@ pub fn switch_to_theme_mode(app: &mut Application) -> Result {
 }
 
 pub fn switch_to_select_mode(app: &mut Application) -> Result {
-    if let Some(buffer) = app.workspace.current_buffer.as_ref() {
-        app.mode = Mode::Select(SelectMode::new(*buffer.cursor.clone()));
-    } else {
-        bail!(BUFFER_MISSING);
+    let position = *app
+        .workspace
+        .current_buffer
+        .as_ref()
+        .ok_or(BUFFER_MISSING)?
+        .cursor;
+
+    app.switch_to(ModeKey::Select);
+    match app.mode {
+        Mode::Select(ref mut mode) => mode.anchor = position,
+        _ => (),
     }
 
     Ok(())

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -73,7 +73,7 @@ pub fn switch_to_line_jump_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
         app.switch_to(ModeKey::LineJump);
         if let Mode::LineJump(ref mut mode) = app.mode {
-            mode.input = String::new()
+            mode.reset();
         }
     } else {
         bail!(BUFFER_MISSING);
@@ -163,7 +163,7 @@ pub fn switch_to_select_mode(app: &mut Application) -> Result {
 
     app.switch_to(ModeKey::Select);
     if let Mode::Select(ref mut mode) = app.mode {
-        mode.anchor = position
+        mode.reset(position);
     }
 
     Ok(())
@@ -180,7 +180,7 @@ pub fn switch_to_select_line_mode(app: &mut Application) -> Result {
 
     app.switch_to(ModeKey::SelectLine);
     if let Mode::SelectLine(ref mut mode) = app.mode {
-        mode.anchor = line
+        mode.reset(line);
     }
 
     Ok(())
@@ -190,7 +190,7 @@ pub fn switch_to_search_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
         app.switch_to(ModeKey::Search);
         if let Mode::Search(ref mut mode) = app.mode {
-            mode.insert = true
+            mode.reset();
         }
     } else {
         bail!(BUFFER_MISSING);

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -51,9 +51,8 @@ pub fn switch_to_jump_mode(app: &mut Application) -> Result {
         .line;
 
     app.switch_to(ModeKey::Jump);
-    match app.mode {
-        Mode::Jump(ref mut mode) => mode.reset(line),
-        _ => (),
+    if let Mode::Jump(ref mut mode) = app.mode {
+        mode.reset(line)
     }
 
     Ok(())
@@ -73,9 +72,8 @@ pub fn switch_to_second_stage_jump_mode(app: &mut Application) -> Result {
 pub fn switch_to_line_jump_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
         app.switch_to(ModeKey::LineJump);
-        match app.mode {
-            Mode::LineJump(ref mut mode) => mode.input = String::new(),
-            _ => (),
+        if let Mode::LineJump(ref mut mode) = app.mode {
+            mode.input = String::new()
         }
     } else {
         bail!(BUFFER_MISSING);
@@ -89,14 +87,13 @@ pub fn switch_to_open_mode(app: &mut Application) -> Result {
     let config = app.preferences.borrow().search_select_config();
 
     app.switch_to(ModeKey::Open);
-    match app.mode {
-        Mode::Open(ref mut mode) => mode.reset(
+    if let Mode::Open(ref mut mode) = app.mode {
+        mode.reset(
             app.workspace.path.clone(),
             exclusions,
             app.event_channel.clone(),
             config,
-        ),
-        _ => (),
+        );
     }
 
     commands::search_select::search(app)?;
@@ -108,9 +105,8 @@ pub fn switch_to_command_mode(app: &mut Application) -> Result {
     let config = app.preferences.borrow().search_select_config();
 
     app.switch_to(ModeKey::Command);
-    match app.mode {
-        Mode::Command(ref mut mode) => mode.reset(config),
-        _ => (),
+    if let Mode::Command(ref mut mode) = app.mode {
+        mode.reset(config)
     }
 
     commands::search_select::search(app)?;
@@ -148,9 +144,8 @@ pub fn switch_to_theme_mode(app: &mut Application) -> Result {
     let config = app.preferences.borrow().search_select_config();
 
     app.switch_to(ModeKey::Theme);
-    match app.mode {
-        Mode::Theme(ref mut mode) => mode.reset(themes, config),
-        _ => (),
+    if let Mode::Theme(ref mut mode) = app.mode {
+        mode.reset(themes, config)
     }
 
     commands::search_select::search(app)?;
@@ -167,9 +162,8 @@ pub fn switch_to_select_mode(app: &mut Application) -> Result {
         .cursor;
 
     app.switch_to(ModeKey::Select);
-    match app.mode {
-        Mode::Select(ref mut mode) => mode.anchor = position,
-        _ => (),
+    if let Mode::Select(ref mut mode) = app.mode {
+        mode.anchor = position
     }
 
     Ok(())
@@ -185,9 +179,8 @@ pub fn switch_to_select_line_mode(app: &mut Application) -> Result {
         .line;
 
     app.switch_to(ModeKey::SelectLine);
-    match app.mode {
-        Mode::SelectLine(ref mut mode) => mode.anchor = line,
-        _ => (),
+    if let Mode::SelectLine(ref mut mode) = app.mode {
+        mode.anchor = line
     }
 
     Ok(())
@@ -196,10 +189,8 @@ pub fn switch_to_select_line_mode(app: &mut Application) -> Result {
 pub fn switch_to_search_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
         app.switch_to(ModeKey::Search);
-
-        match app.mode {
-            Mode::Search(ref mut mode) => mode.insert = true,
-            _ => (),
+        if let Mode::Search(ref mut mode) = app.mode {
+            mode.insert = true
         }
     } else {
         bail!(BUFFER_MISSING);
@@ -224,9 +215,8 @@ pub fn switch_to_path_mode(app: &mut Application) -> Result {
             format!("{}/", app.workspace.path.to_string_lossy()));
 
     app.switch_to(ModeKey::Path);
-    match app.mode {
-        Mode::Path(ref mut mode) => mode.reset(path),
-        _ => (),
+    if let Mode::Path(ref mut mode) = app.mode {
+        mode.reset(path)
     }
 
     Ok(())
@@ -250,9 +240,8 @@ pub fn switch_to_syntax_mode(app: &mut Application) -> Result {
         .iter()
         .map(|syntax| syntax.name.clone())
         .collect();
-    match app.mode {
-        Mode::Syntax(ref mut mode) => mode.reset(syntaxes, config),
-        _ => (),
+    if let Mode::Syntax(ref mut mode) = app.mode {
+        mode.reset(syntaxes, config)
     }
 
     commands::search_select::search(app)?;

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -1,7 +1,6 @@
 use crate::commands::{self, Result};
 use crate::errors::*;
 use crate::input::KeyMap;
-use crate::models::application::modes::*;
 use crate::models::application::{Application, Mode, ModeKey};
 use crate::util;
 use scribe::Buffer;
@@ -107,7 +106,13 @@ pub fn switch_to_open_mode(app: &mut Application) -> Result {
 
 pub fn switch_to_command_mode(app: &mut Application) -> Result {
     let config = app.preferences.borrow().search_select_config();
-    app.mode = Mode::Command(CommandMode::new(config));
+
+    app.switch_to(ModeKey::Command);
+    match app.mode {
+        Mode::Command(ref mut mode) => mode.reset(config),
+        _ => (),
+    }
+
     commands::search_select::search(app)?;
 
     Ok(())

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -187,7 +187,12 @@ pub fn switch_to_path_mode(app: &mut Application) -> Result {
         .unwrap_or_else(||
             // Default to the workspace directory.
             format!("{}/", app.workspace.path.to_string_lossy()));
-    app.mode = Mode::Path(PathMode::new(path));
+
+    app.switch_to(ModeKey::Path);
+    match app.mode {
+        Mode::Path(ref mut mode) => mode.reset(path),
+        _ => (),
+    }
 
     Ok(())
 }

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -133,16 +133,21 @@ pub fn switch_to_symbol_jump_mode(app: &mut Application) -> Result {
 }
 
 pub fn switch_to_theme_mode(app: &mut Application) -> Result {
+    let themes = app
+        .view
+        .theme_set
+        .themes
+        .keys()
+        .map(|k| k.to_string())
+        .collect();
     let config = app.preferences.borrow().search_select_config();
-    app.mode = Mode::Theme(ThemeMode::new(
-        app.view
-            .theme_set
-            .themes
-            .keys()
-            .map(|k| k.to_string())
-            .collect(),
-        config,
-    ));
+
+    app.switch_to(ModeKey::Theme);
+    match app.mode {
+        Mode::Theme(ref mut mode) => mode.reset(themes, config),
+        _ => (),
+    }
+
     commands::search_select::search(app)?;
 
     Ok(())

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -161,10 +161,18 @@ pub fn switch_to_select_mode(app: &mut Application) -> Result {
 }
 
 pub fn switch_to_select_line_mode(app: &mut Application) -> Result {
-    if let Some(buffer) = app.workspace.current_buffer.as_ref() {
-        app.mode = Mode::SelectLine(SelectLineMode::new(buffer.cursor.line));
-    } else {
-        bail!(BUFFER_MISSING);
+    let line = app
+        .workspace
+        .current_buffer
+        .as_ref()
+        .ok_or(BUFFER_MISSING)?
+        .cursor
+        .line;
+
+    app.switch_to(ModeKey::SelectLine);
+    match app.mode {
+        Mode::SelectLine(ref mut mode) => mode.anchor = line,
+        _ => (),
     }
 
     Ok(())

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -231,16 +231,20 @@ pub fn switch_to_syntax_mode(app: &mut Application) -> Result {
         .as_ref()
         .ok_or("Switching syntaxes requires an open buffer")?;
 
+    app.switch_to(ModeKey::Syntax);
     let config = app.preferences.borrow().search_select_config();
-    app.mode = Mode::Syntax(SyntaxMode::new(
-        app.workspace
-            .syntax_set
-            .syntaxes()
-            .iter()
-            .map(|syntax| syntax.name.clone())
-            .collect(),
-        config,
-    ));
+    let syntaxes = app
+        .workspace
+        .syntax_set
+        .syntaxes()
+        .iter()
+        .map(|syntax| syntax.name.clone())
+        .collect();
+    match app.mode {
+        Mode::Syntax(ref mut mode) => mode.reset(syntaxes, config),
+        _ => (),
+    }
+
     commands::search_select::search(app)?;
 
     Ok(())

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -165,7 +165,12 @@ pub fn switch_to_select_line_mode(app: &mut Application) -> Result {
 
 pub fn switch_to_search_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
-        app.mode = Mode::Search(SearchMode::new(app.search_query.clone()));
+        app.switch_to(ModeKey::Search);
+
+        match app.mode {
+            Mode::Search(ref mut mode) => mode.insert = true,
+            _ => (),
+        }
     } else {
         bail!(BUFFER_MISSING);
     }
@@ -313,24 +318,6 @@ mod tests {
             Some("application::display_available_commands")
         );
         assert_eq!(lines.last(), Some("workspace::next_buffer"));
-    }
-
-    #[test]
-    fn switch_to_search_mode_sets_initial_search_query() {
-        let mut app = Application::new(&Vec::new()).unwrap();
-
-        // A buffer needs to be open to switch to search mode.
-        let buffer = Buffer::new();
-        app.workspace.add_buffer(buffer);
-
-        app.search_query = Some(String::from("query"));
-        super::switch_to_search_mode(&mut app).unwrap();
-
-        let mode_query = match app.mode {
-            Mode::Search(ref mode) => mode.input.clone(),
-            _ => None,
-        };
-        assert_eq!(mode_query, Some(String::from("query")));
     }
 
     #[test]

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -189,9 +189,6 @@ pub fn switch_to_select_line_mode(app: &mut Application) -> Result {
 pub fn switch_to_search_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
         app.switch_to(ModeKey::Search);
-        if let Mode::Search(ref mut mode) = app.mode {
-            mode.reset();
-        }
     } else {
         bail!(BUFFER_MISSING);
     }

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -114,13 +114,18 @@ pub fn switch_to_command_mode(app: &mut Application) -> Result {
 }
 
 pub fn switch_to_symbol_jump_mode(app: &mut Application) -> Result {
+    app.switch_to(ModeKey::SymbolJump);
+
     let token_set = app
         .workspace
         .current_buffer_tokens()
         .chain_err(|| BUFFER_TOKENS_FAILED)?;
     let config = app.preferences.borrow().search_select_config();
 
-    app.mode = Mode::SymbolJump(SymbolJumpMode::new(&token_set, config)?);
+    match app.mode {
+        Mode::SymbolJump(ref mut mode) => mode.reset(&token_set, config),
+        _ => Ok(()),
+    }?;
 
     commands::search_select::search(app)?;
 

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -88,12 +88,18 @@ pub fn switch_to_line_jump_mode(app: &mut Application) -> Result {
 pub fn switch_to_open_mode(app: &mut Application) -> Result {
     let exclusions = app.preferences.borrow().open_mode_exclusions()?;
     let config = app.preferences.borrow().search_select_config();
-    app.mode = Mode::Open(OpenMode::new(
-        app.workspace.path.clone(),
-        exclusions,
-        app.event_channel.clone(),
-        config,
-    ));
+
+    app.switch_to(ModeKey::Open);
+    match app.mode {
+        Mode::Open(ref mut mode) => mode.reset(
+            app.workspace.path.clone(),
+            exclusions,
+            app.event_channel.clone(),
+            config,
+        ),
+        _ => (),
+    }
+
     commands::search_select::search(app)?;
 
     Ok(())

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -2,7 +2,7 @@ use crate::commands::{self, Result};
 use crate::errors::*;
 use crate::input::KeyMap;
 use crate::models::application::modes::*;
-use crate::models::application::{Application, Mode};
+use crate::models::application::{Application, Mode, ModeKey};
 use crate::util;
 use scribe::Buffer;
 use std::mem;
@@ -26,7 +26,7 @@ pub fn handle_input(app: &mut Application) -> Result {
 
 pub fn switch_to_normal_mode(app: &mut Application) -> Result {
     let _ = commands::buffer::end_command_group(app);
-    app.mode = Mode::Normal;
+    app.switch_to(ModeKey::Normal);
 
     Ok(())
 }
@@ -34,7 +34,7 @@ pub fn switch_to_normal_mode(app: &mut Application) -> Result {
 pub fn switch_to_insert_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
         commands::buffer::start_command_group(app)?;
-        app.mode = Mode::Insert;
+        app.switch_to(ModeKey::Insert);
         commands::view::scroll_to_cursor(app)?;
     } else {
         bail!(BUFFER_MISSING);
@@ -282,7 +282,7 @@ pub fn suspend(app: &mut Application) -> Result {
 }
 
 pub fn exit(app: &mut Application) -> Result {
-    app.mode = Mode::Exit;
+    app.switch_to(ModeKey::Exit);
 
     Ok(())
 }

--- a/src/commands/application.rs
+++ b/src/commands/application.rs
@@ -73,7 +73,11 @@ pub fn switch_to_second_stage_jump_mode(app: &mut Application) -> Result {
 
 pub fn switch_to_line_jump_mode(app: &mut Application) -> Result {
     if app.workspace.current_buffer.is_some() {
-        app.mode = Mode::LineJump(LineJumpMode::new());
+        app.switch_to(ModeKey::LineJump);
+        match app.mode {
+            Mode::LineJump(ref mut mode) => mode.input = String::new(),
+            _ => (),
+        }
     } else {
         bail!(BUFFER_MISSING);
     }

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -204,9 +204,8 @@ pub fn close(app: &mut Application) -> Result {
     } else {
         // Display a confirmation prompt before closing a modified buffer.
         app.switch_to(ModeKey::Confirm);
-        match app.mode {
-            Mode::Confirm(ref mut mode) => mode.command = close,
-            _ => (),
+        if let Mode::Confirm(ref mut mode) = app.mode {
+            mode.command = close
         }
     }
 
@@ -252,10 +251,10 @@ pub fn close_others(app: &mut Application) -> Result {
         if modified_buffer {
             // Display a confirmation prompt before closing a modified buffer.
             app.switch_to(ModeKey::Confirm);
-            match app.mode {
-                Mode::Confirm(ref mut mode) => mode.command = close_others_confirm,
-                _ => (),
+            if let Mode::Confirm(ref mut mode) = app.mode {
+                mode.command = close_others_confirm
             }
+
             break;
         }
 

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -1,8 +1,7 @@
 use crate::commands::{self, Result};
 use crate::errors::*;
 use crate::input::Key;
-use crate::models::application::modes::ConfirmMode;
-use crate::models::application::{Application, ClipboardContent, Mode};
+use crate::models::application::{Application, ClipboardContent, Mode, ModeKey};
 use crate::util;
 use crate::util::token::{adjacent_token_position, Direction};
 use scribe::buffer::{Buffer, Position, Range, Token};
@@ -204,8 +203,11 @@ pub fn close(app: &mut Application) -> Result {
         app.workspace.close_current_buffer();
     } else {
         // Display a confirmation prompt before closing a modified buffer.
-        let confirm_mode = ConfirmMode::new(close);
-        app.mode = Mode::Confirm(confirm_mode);
+        app.switch_to(ModeKey::Confirm);
+        match app.mode {
+            Mode::Confirm(ref mut mode) => mode.command = close,
+            _ => (),
+        }
     }
 
     Ok(())
@@ -249,8 +251,11 @@ pub fn close_others(app: &mut Application) -> Result {
 
         if modified_buffer {
             // Display a confirmation prompt before closing a modified buffer.
-            let confirm_mode = ConfirmMode::new(close_others_confirm);
-            app.mode = Mode::Confirm(confirm_mode);
+            app.switch_to(ModeKey::Confirm);
+            match app.mode {
+                Mode::Confirm(ref mut mode) => mode.command = close_others_confirm,
+                _ => (),
+            }
             break;
         }
 

--- a/src/commands/jump.rs
+++ b/src/commands/jump.rs
@@ -1,11 +1,9 @@
 use crate::commands::Result;
 use crate::errors::*;
 use crate::input::Key;
-use crate::models::application::modes::jump;
 use crate::models::application::modes::JumpMode;
 use crate::models::application::{Application, Mode};
 use scribe::Workspace;
-use std::mem;
 
 pub fn match_tag(app: &mut Application) -> Result {
     let result = if let Mode::Jump(ref mut jump_mode) = app.mode {
@@ -23,7 +21,7 @@ pub fn match_tag(app: &mut Application) -> Result {
     } else {
         bail!("Can't match jump tags outside of jump mode.");
     };
-    switch_to_previous_mode(app);
+    app.switch_to_previous_mode();
 
     result
 }
@@ -43,24 +41,6 @@ fn jump_to_tag(jump_mode: &mut JumpMode, workspace: &mut Workspace) -> Result {
     }
 
     Ok(())
-}
-
-fn switch_to_previous_mode(app: &mut Application) {
-    let old_mode = mem::replace(&mut app.mode, Mode::Normal);
-
-    // Now that we own the jump mode, switch to
-    // the previous select mode, if there was one.
-    if let Mode::Jump(jump_mode) = old_mode {
-        match jump_mode.select_mode {
-            jump::SelectModeOptions::None => (),
-            jump::SelectModeOptions::Select(select_mode) => {
-                app.mode = Mode::Select(select_mode);
-            }
-            jump::SelectModeOptions::SelectLine(select_mode) => {
-                app.mode = Mode::SelectLine(select_mode);
-            }
-        }
-    }
 }
 
 pub fn push_search_char(app: &mut Application) -> Result {

--- a/src/commands/path.rs
+++ b/src/commands/path.rs
@@ -1,7 +1,7 @@
 use crate::commands::{self, Result};
 use crate::errors::*;
 use crate::input::Key;
-use crate::models::application::{Application, Mode};
+use crate::models::application::{Application, Mode, ModeKey};
 use std::path::PathBuf;
 
 pub fn push_char(app: &mut Application) -> Result {
@@ -51,7 +51,7 @@ pub fn accept_path(app: &mut Application) -> Result {
     app.workspace
         .update_current_syntax()
         .chain_err(|| BUFFER_SYNTAX_UPDATE_FAILED)?;
-    app.mode = Mode::Normal;
+    app.switch_to(ModeKey::Normal);
 
     if save_on_accept {
         commands::buffer::save(app)

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -67,11 +67,11 @@ pub fn accept_query(app: &mut Application) -> Result {
     Ok(())
 }
 
-pub fn clear_query(app: &mut Application) -> Result {
+pub fn reset(app: &mut Application) -> Result {
     if let Mode::Search(ref mut mode) = app.mode {
-        mode.input = None;
+        mode.reset();
     } else {
-        bail!("Can't clear search outside of search mode");
+        bail!("Can't reset search outside of search mode");
     };
 
     Ok(())

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -70,7 +70,6 @@ pub fn accept_query(app: &mut Application) -> Result {
 pub fn clear_query(app: &mut Application) -> Result {
     if let Mode::Search(ref mut mode) = app.mode {
         mode.input = None;
-        app.search_query = None;
     } else {
         bail!("Can't clear search outside of search mode");
     };
@@ -89,7 +88,6 @@ pub fn push_search_char(app: &mut Application) -> Result {
         if let Mode::Search(ref mut mode) = app.mode {
             let query = mode.input.get_or_insert(String::new());
             query.push(c);
-            app.search_query = Some(query.clone());
         } else {
             bail!("Can't push search character outside of search mode");
         }
@@ -105,7 +103,6 @@ pub fn pop_search_char(app: &mut Application) -> Result {
         let query = mode.input.as_mut().ok_or(SEARCH_QUERY_MISSING)?;
 
         query.pop();
-        app.search_query = Some(query.clone());
     } else {
         bail!("Can't pop search character outside of search mode");
     };
@@ -280,9 +277,12 @@ mod tests {
         buffer.cursor.move_to(Position { line: 0, offset: 4 });
         app.workspace.add_buffer(buffer);
 
-        // Add a search query, enter search mode, and accept the query.
-        app.search_query = Some(String::from("ed"));
+        // Enter search mode, add a query, and accept the query.
         commands::application::switch_to_search_mode(&mut app).unwrap();
+        match app.mode {
+            Mode::Search(ref mut mode) => mode.input = Some("ed".into()),
+            _ => (),
+        }
         commands::search::accept_query(&mut app).unwrap();
 
         // Ensure that we've disabled insert sub-mode.
@@ -290,9 +290,6 @@ mod tests {
             crate::models::application::Mode::Search(ref mode) => !mode.insert_mode(),
             _ => false,
         });
-
-        // Ensure that the search query is properly set.
-        assert_eq!(app.search_query, Some("ed".to_string()));
 
         // Ensure the buffer cursor is at the expected position.
         assert_eq!(

--- a/src/commands/search_select.rs
+++ b/src/commands/search_select.rs
@@ -3,16 +3,10 @@ use crate::errors::*;
 use crate::input::Key;
 use crate::models::application::modes::open::DisplayablePath;
 use crate::models::application::modes::SearchSelectMode;
-use crate::models::application::{Application, Mode};
-use std::mem;
+use crate::models::application::{Application, Mode, ModeKey};
 
 pub fn accept(app: &mut Application) -> Result {
-    // Consume the application mode. This is necessary because the selection in
-    // command mode needs to run against the application, but we can't hold the
-    // reference to the selection and lend the app mutably to it at the time.
-    let mut app_mode = mem::replace(&mut app.mode, Mode::Normal);
-
-    match app_mode {
+    match app.mode {
         Mode::Command(ref mode) => {
             let selection = mode.selection().ok_or("No command selected")?;
 
@@ -76,6 +70,7 @@ pub fn accept(app: &mut Application) -> Result {
         _ => bail!("Can't accept selection outside of search select mode."),
     }
 
+    app.switch_to(ModeKey::Normal);
     commands::view::scroll_cursor_to_center(app).ok();
 
     Ok(())

--- a/src/commands/selection.rs
+++ b/src/commands/selection.rs
@@ -222,8 +222,11 @@ mod tests {
         // Now that we've set up the buffer, add it
         // to the application and call the command.
         app.workspace.add_buffer(buffer);
-        app.search_query = Some(String::from("ed"));
         commands::application::switch_to_search_mode(&mut app).unwrap();
+        match app.mode {
+            Mode::Search(ref mut mode) => mode.input = Some("ed".into()),
+            _ => (),
+        }
         commands::search::accept_query(&mut app).unwrap();
         commands::selection::delete(&mut app).unwrap();
 

--- a/src/input/key_map/default.yml
+++ b/src/input/key_map/default.yml
@@ -58,7 +58,7 @@ normal:
   "#": application::switch_to_syntax_mode
   /:
     - application::switch_to_search_mode
-    - search::clear_query
+    - search::reset
   ",": view::scroll_up
   ">": buffer::indent_line
   "<": buffer::outdent_line
@@ -125,7 +125,7 @@ search:
     - search::run
   /:
     - application::switch_to_search_mode
-    - search::clear_query
+    - search::reset
   m: view::scroll_down
   ",": view::scroll_up
   n: search::move_to_next_result

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -265,6 +265,10 @@ impl Application {
             ModeKey::Select,
             Mode::Select(SelectMode::new(Position::default())),
         );
+        self.modes.insert(
+            ModeKey::SelectLine,
+            Mode::SelectLine(SelectLineMode::new(0)),
+        );
 
         Ok(())
     }

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -276,8 +276,6 @@ impl Application {
             ModeKey::Open,
             Mode::Open(OpenMode::new(
                 self.workspace.path.clone(),
-                self.preferences.borrow().open_mode_exclusions()?,
-                self.event_channel.clone(),
                 self.preferences.borrow().search_select_config(),
             )),
         );

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -6,7 +6,7 @@ mod preferences;
 // Published API
 pub use self::clipboard::ClipboardContent;
 pub use self::event::Event;
-pub use self::modes::Mode;
+pub use self::modes::{Mode, ModeKey};
 pub use self::preferences::Preferences;
 
 use self::clipboard::Clipboard;

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -6,6 +6,7 @@ mod preferences;
 // Published API
 pub use self::clipboard::ClipboardContent;
 pub use self::event::Event;
+pub use self::modes::Mode;
 pub use self::preferences::Preferences;
 
 use self::clipboard::Clipboard;
@@ -21,24 +22,6 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::mpsc::{self, Receiver, Sender};
-
-pub enum Mode {
-    Confirm(ConfirmMode),
-    Command(CommandMode),
-    Exit,
-    Insert,
-    Jump(JumpMode),
-    LineJump(LineJumpMode),
-    Path(PathMode),
-    Normal,
-    Open(OpenMode),
-    Select(SelectMode),
-    SelectLine(SelectLineMode),
-    Search(SearchMode),
-    SymbolJump(SymbolJumpMode),
-    Syntax(SyntaxMode),
-    Theme(ThemeMode),
-}
 
 pub struct Application {
     pub mode: Mode,

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -256,6 +256,8 @@ impl Application {
                 self.preferences.borrow().search_select_config(),
             )),
         );
+        self.modes
+            .insert(ModeKey::Path, Mode::Path(PathMode::new(String::new())));
 
         Ok(())
     }

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -18,13 +18,16 @@ use crate::view::View;
 use git2::Repository;
 use scribe::{Buffer, Workspace};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::mpsc::{self, Receiver, Sender};
 
 pub struct Application {
+    pub current_mode: ModeKey,
     pub mode: Mode,
+    pub modes: HashMap<ModeKey, Mode>,
     pub workspace: Workspace,
     pub search_query: Option<String>,
     pub view: View,
@@ -48,7 +51,9 @@ impl Application {
         let workspace = create_workspace(&mut view, &preferences.borrow(), args)?;
 
         Ok(Application {
+            current_mode: ModeKey::Normal,
             mode: Mode::Normal,
+            modes: HashMap::new(),
             workspace,
             search_query: None,
             view,

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -16,7 +16,7 @@ use crate::errors::*;
 use crate::presenters;
 use crate::view::View;
 use git2::Repository;
-use scribe::buffer::Position;
+use scribe::buffer::{Position, TokenSet};
 use scribe::{Buffer, Workspace};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -268,6 +268,17 @@ impl Application {
         self.modes.insert(
             ModeKey::SelectLine,
             Mode::SelectLine(SelectLineMode::new(0)),
+        );
+        self.modes.insert(
+            ModeKey::SymbolJump,
+            Mode::SymbolJump(SymbolJumpMode::new(
+                &TokenSet::new(
+                    String::new(),
+                    &self.workspace.syntax_set.find_syntax_plain_text(),
+                    &self.workspace.syntax_set,
+                ),
+                self.preferences.borrow().search_select_config(),
+            )?),
         );
 
         Ok(())

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -280,7 +280,7 @@ impl Application {
             )),
         );
         self.modes
-            .insert(ModeKey::Path, Mode::Path(PathMode::new(String::new())));
+            .insert(ModeKey::Path, Mode::Path(PathMode::new()));
         self.modes
             .insert(ModeKey::Search, Mode::Search(SearchMode::new(None)));
         self.modes.insert(

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -27,9 +27,7 @@ use std::rc::Rc;
 use std::sync::mpsc::{self, Receiver, Sender};
 
 pub struct Application {
-    pub current_mode: ModeKey,
     pub mode: Mode,
-    pub modes: HashMap<ModeKey, Mode>,
     pub workspace: Workspace,
     pub search_query: Option<String>,
     pub view: View,
@@ -39,6 +37,8 @@ pub struct Application {
     pub preferences: Rc<RefCell<Preferences>>,
     pub event_channel: Sender<Event>,
     events: Receiver<Event>,
+    current_mode: ModeKey,
+    modes: HashMap<ModeKey, Mode>,
 }
 
 impl Application {

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -258,6 +258,8 @@ impl Application {
         );
         self.modes
             .insert(ModeKey::Path, Mode::Path(PathMode::new(String::new())));
+        self.modes
+            .insert(ModeKey::Search, Mode::Search(SearchMode::new(None)));
 
         Ok(())
     }

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -304,7 +304,6 @@ impl Application {
         self.modes.insert(
             ModeKey::Theme,
             Mode::Theme(ThemeMode::new(
-                Vec::new(),
                 self.preferences.borrow().search_select_config(),
             )),
         );

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -65,7 +65,7 @@ impl Application {
             events,
         };
 
-        app.create_modes();
+        app.create_modes()?;
 
         Ok(app)
     }
@@ -223,7 +223,7 @@ impl Application {
         }
     }
 
-    fn create_modes(&mut self) {
+    fn create_modes(&mut self) -> Result<()> {
         // Do the easy ones first.
         self.modes.insert(ModeKey::Exit, Mode::Exit);
         self.modes.insert(ModeKey::Insert, Mode::Insert);
@@ -245,6 +245,19 @@ impl Application {
             .insert(ModeKey::Jump, Mode::Jump(JumpMode::new(0)));
         self.modes
             .insert(ModeKey::LineJump, Mode::LineJump(LineJumpMode::new()));
+        self.modes
+            .insert(ModeKey::LineJump, Mode::LineJump(LineJumpMode::new()));
+        self.modes.insert(
+            ModeKey::Open,
+            Mode::Open(OpenMode::new(
+                self.workspace.path.clone(),
+                self.preferences.borrow().open_mode_exclusions()?,
+                self.event_channel.clone(),
+                self.preferences.borrow().search_select_config(),
+            )),
+        );
+
+        Ok(())
     }
 }
 

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -53,7 +53,7 @@ impl Application {
         Ok(Application {
             current_mode: ModeKey::Normal,
             mode: Mode::Normal,
-            modes: HashMap::new(),
+            modes: create_modes(),
             workspace,
             search_query: None,
             view,
@@ -296,6 +296,17 @@ fn create_workspace(
     }
 
     Ok(workspace)
+}
+
+fn create_modes() -> HashMap<ModeKey, Mode> {
+    let mut modes = HashMap::new();
+
+    // Do the easy ones first.
+    modes.insert(ModeKey::Exit, Mode::Exit);
+    modes.insert(ModeKey::Insert, Mode::Insert);
+    modes.insert(ModeKey::Normal, Mode::Normal);
+
+    return modes;
 }
 
 #[cfg(not(any(test, feature = "bench")))]

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -281,6 +281,13 @@ impl Application {
             )?),
         );
 
+        self.modes.insert(
+            ModeKey::Syntax,
+            Mode::Syntax(SyntaxMode::new(
+                Vec::new(),
+                self.preferences.borrow().search_select_config(),
+            )),
+        );
         Ok(())
     }
 }

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -235,6 +235,12 @@ impl Application {
                 self.preferences.borrow().search_select_config(),
             )),
         );
+        self.modes.insert(
+            ModeKey::Confirm,
+            Mode::Confirm(ConfirmMode::new(
+                commands::application::switch_to_normal_mode,
+            )),
+        );
     }
 }
 

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -280,7 +280,6 @@ impl Application {
                 self.preferences.borrow().search_select_config(),
             )?),
         );
-
         self.modes.insert(
             ModeKey::Syntax,
             Mode::Syntax(SyntaxMode::new(
@@ -288,6 +287,14 @@ impl Application {
                 self.preferences.borrow().search_select_config(),
             )),
         );
+        self.modes.insert(
+            ModeKey::Theme,
+            Mode::Theme(ThemeMode::new(
+                Vec::new(),
+                self.preferences.borrow().search_select_config(),
+            )),
+        );
+
         Ok(())
     }
 }

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -16,6 +16,7 @@ use crate::errors::*;
 use crate::presenters;
 use crate::view::View;
 use git2::Repository;
+use scribe::buffer::Position;
 use scribe::{Buffer, Workspace};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -260,6 +261,10 @@ impl Application {
             .insert(ModeKey::Path, Mode::Path(PathMode::new(String::new())));
         self.modes
             .insert(ModeKey::Search, Mode::Search(SearchMode::new(None)));
+        self.modes.insert(
+            ModeKey::Select,
+            Mode::Select(SelectMode::new(Position::default())),
+        );
 
         Ok(())
     }

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -243,6 +243,8 @@ impl Application {
         );
         self.modes
             .insert(ModeKey::Jump, Mode::Jump(JumpMode::new(0)));
+        self.modes
+            .insert(ModeKey::LineJump, Mode::LineJump(LineJumpMode::new()));
     }
 }
 

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -298,7 +298,6 @@ impl Application {
         self.modes.insert(
             ModeKey::Syntax,
             Mode::Syntax(SyntaxMode::new(
-                Vec::new(),
                 self.preferences.borrow().search_select_config(),
             )),
         );

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -29,7 +29,6 @@ use std::sync::mpsc::{self, Receiver, Sender};
 pub struct Application {
     pub mode: Mode,
     pub workspace: Workspace,
-    pub search_query: Option<String>,
     pub view: View,
     pub clipboard: Clipboard,
     pub repository: Option<Repository>,
@@ -59,7 +58,6 @@ impl Application {
             mode: Mode::Normal,
             modes: HashMap::new(),
             workspace,
-            search_query: None,
             view,
             clipboard,
             repository: Repository::discover(env::current_dir()?).ok(),

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -241,6 +241,8 @@ impl Application {
                 commands::application::switch_to_normal_mode,
             )),
         );
+        self.modes
+            .insert(ModeKey::Jump, Mode::Jump(JumpMode::new(0)));
     }
 }
 

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -16,7 +16,7 @@ use crate::errors::*;
 use crate::presenters;
 use crate::view::View;
 use git2::Repository;
-use scribe::buffer::{Position, TokenSet};
+use scribe::buffer::Position;
 use scribe::{Buffer, Workspace};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -292,11 +292,6 @@ impl Application {
         self.modes.insert(
             ModeKey::SymbolJump,
             Mode::SymbolJump(SymbolJumpMode::new(
-                &TokenSet::new(
-                    String::new(),
-                    &self.workspace.syntax_set.find_syntax_plain_text(),
-                    &self.workspace.syntax_set,
-                ),
                 self.preferences.borrow().search_select_config(),
             )?),
         );

--- a/src/models/application/mod.rs
+++ b/src/models/application/mod.rs
@@ -226,6 +226,10 @@ impl Application {
     }
 
     pub fn switch_to(&mut self, mode_key: ModeKey) {
+        if self.current_mode == mode_key {
+            return;
+        }
+
         // Check out the specified mode.
         let mut mode = self.modes.remove(&mode_key).unwrap();
 
@@ -524,6 +528,21 @@ mod tests {
         assert!(matches!(app.mode, Mode::Exit));
 
         app.switch_to_previous_mode();
+
+        assert_eq!(app.current_mode, ModeKey::Insert);
+        assert!(matches!(app.mode, Mode::Insert));
+    }
+
+    #[test]
+    fn switch_to_handles_switching_to_current_mode() {
+        let mut app = Application::new(&Vec::new()).unwrap();
+
+        app.switch_to(ModeKey::Insert);
+
+        assert_eq!(app.current_mode, ModeKey::Insert);
+        assert!(matches!(app.mode, Mode::Insert));
+
+        app.switch_to(ModeKey::Insert);
 
         assert_eq!(app.current_mode, ModeKey::Insert);
         assert!(matches!(app.mode, Mode::Insert));

--- a/src/models/application/modes/command/mod.rs
+++ b/src/models/application/modes/command/mod.rs
@@ -27,6 +27,10 @@ impl CommandMode {
             config,
         }
     }
+
+    pub fn reset(&mut self, config: SearchSelectConfig) {
+        self.config = config;
+    }
 }
 
 impl fmt::Display for CommandMode {

--- a/src/models/application/modes/jump/mod.rs
+++ b/src/models/application/modes/jump/mod.rs
@@ -3,21 +3,11 @@ mod tag_generator;
 
 use self::single_character_tag_generator::SingleCharacterTagGenerator;
 use self::tag_generator::TagGenerator;
-use crate::models::application::modes::select::SelectMode;
-use crate::models::application::modes::select_line::SelectLineMode;
 use crate::util::movement_lexer;
 use crate::view::{LexemeMapper, MappedLexeme};
 use luthor::token::Category;
 use scribe::buffer::{Distance, Position};
 use std::collections::HashMap;
-
-/// Used to compose select and jump modes, allowing jump mode
-/// to be used for cursor navigation (to select a range of text).
-pub enum SelectModeOptions {
-    None,
-    Select(SelectMode),
-    SelectLine(SelectLineMode),
-}
 
 enum MappedLexemeValue {
     Tag((String, Position)),
@@ -28,7 +18,6 @@ pub struct JumpMode {
     pub input: String,
     pub first_phase: bool,
     cursor_line: usize,
-    pub select_mode: SelectModeOptions,
     tag_positions: HashMap<String, Position>,
     tag_generator: TagGenerator,
     single_characters: SingleCharacterTagGenerator,
@@ -42,11 +31,10 @@ impl JumpMode {
             input: String::new(),
             first_phase: true,
             cursor_line,
-            select_mode: SelectModeOptions::None,
             tag_positions: HashMap::new(),
             tag_generator: TagGenerator::new(),
             single_characters: SingleCharacterTagGenerator::new(),
-            current_position: Position { line: 0, offset: 0 },
+            current_position: Position::default(),
             mapped_lexeme_values: Vec::new(),
         }
     }
@@ -59,6 +47,15 @@ impl JumpMode {
         self.tag_positions.clear();
         self.tag_generator.reset();
         self.single_characters.reset();
+    }
+
+    pub fn reset(&mut self, cursor_line: usize) {
+        self.input = String::new();
+        self.first_phase = true;
+        self.current_position = Position::default();
+        self.cursor_line = cursor_line;
+        self.mapped_lexeme_values = Vec::new();
+        self.reset_display();
     }
 }
 

--- a/src/models/application/modes/line_jump.rs
+++ b/src/models/application/modes/line_jump.rs
@@ -7,4 +7,8 @@ impl LineJumpMode {
     pub fn new() -> LineJumpMode {
         LineJumpMode::default()
     }
+
+    pub fn reset(&mut self) {
+        self.input = String::new();
+    }
 }

--- a/src/models/application/modes/mod.rs
+++ b/src/models/application/modes/mod.rs
@@ -30,7 +30,7 @@ pub enum Mode {
     Theme(ThemeMode),
 }
 
-#[derive(Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ModeKey {
     Command,
     Confirm,

--- a/src/models/application/modes/mod.rs
+++ b/src/models/application/modes/mod.rs
@@ -30,6 +30,25 @@ pub enum Mode {
     Theme(ThemeMode),
 }
 
+#[derive(Eq, Hash, PartialEq)]
+pub enum ModeKey {
+    Command,
+    Confirm,
+    Exit,
+    Insert,
+    Jump,
+    LineJump,
+    Normal,
+    Open,
+    Path,
+    Search,
+    Select,
+    SelectLine,
+    SymbolJump,
+    Syntax,
+    Theme,
+}
+
 pub use self::command::CommandMode;
 pub use self::confirm::ConfirmMode;
 pub use self::jump::JumpMode;

--- a/src/models/application/modes/mod.rs
+++ b/src/models/application/modes/mod.rs
@@ -12,6 +12,24 @@ mod symbol_jump;
 mod syntax;
 mod theme;
 
+pub enum Mode {
+    Command(CommandMode),
+    Confirm(ConfirmMode),
+    Exit,
+    Insert,
+    Jump(JumpMode),
+    LineJump(LineJumpMode),
+    Normal,
+    Open(OpenMode),
+    Path(PathMode),
+    Search(SearchMode),
+    Select(SelectMode),
+    SelectLine(SelectLineMode),
+    SymbolJump(SymbolJumpMode),
+    Syntax(SyntaxMode),
+    Theme(ThemeMode),
+}
+
 pub use self::command::CommandMode;
 pub use self::confirm::ConfirmMode;
 pub use self::jump::JumpMode;

--- a/src/models/application/modes/path.rs
+++ b/src/models/application/modes/path.rs
@@ -6,17 +6,24 @@ pub struct PathMode {
 }
 
 impl PathMode {
-    pub fn new(initial_path: String) -> PathMode {
+    pub fn new() -> PathMode {
         PathMode {
-            input: initial_path,
+            input: String::new(),
             save_on_accept: false,
         }
     }
+
     pub fn push_char(&mut self, c: char) {
         self.input.push(c);
     }
+
     pub fn pop_char(&mut self) {
         self.input.pop();
+    }
+
+    pub fn reset(&mut self, initial_path: String) {
+        self.input = initial_path;
+        self.save_on_accept = false;
     }
 }
 

--- a/src/models/application/modes/path.rs
+++ b/src/models/application/modes/path.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+#[derive(Default)]
 pub struct PathMode {
     pub input: String,
     pub save_on_accept: bool,
@@ -7,10 +8,7 @@ pub struct PathMode {
 
 impl PathMode {
     pub fn new() -> PathMode {
-        PathMode {
-            input: String::new(),
-            save_on_accept: false,
-        }
+        PathMode::default()
     }
 
     pub fn push_char(&mut self, c: char) {

--- a/src/models/application/modes/search.rs
+++ b/src/models/application/modes/search.rs
@@ -20,6 +20,8 @@ impl SearchMode {
 
     pub fn reset(&mut self) {
         self.insert = true;
+        self.input = None;
+        self.results = None;
     }
 
     pub fn insert_mode(&self) -> bool {

--- a/src/models/application/modes/search.rs
+++ b/src/models/application/modes/search.rs
@@ -18,6 +18,10 @@ impl SearchMode {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.insert = true;
+    }
+
     pub fn insert_mode(&self) -> bool {
         self.insert
     }

--- a/src/models/application/modes/select.rs
+++ b/src/models/application/modes/select.rs
@@ -8,4 +8,8 @@ impl SelectMode {
     pub fn new(anchor: Position) -> SelectMode {
         SelectMode { anchor }
     }
+
+    pub fn reset(&mut self, anchor: Position) {
+        self.anchor = anchor;
+    }
 }

--- a/src/models/application/modes/select_line.rs
+++ b/src/models/application/modes/select_line.rs
@@ -9,6 +9,10 @@ impl SelectLineMode {
         SelectLineMode { anchor }
     }
 
+    pub fn reset(&mut self, anchor: usize) {
+        self.anchor = anchor;
+    }
+
     pub fn to_range(&self, cursor: &Position) -> Range {
         LineRange::new(self.anchor, cursor.line).to_inclusive_range()
     }

--- a/src/models/application/modes/symbol_jump.rs
+++ b/src/models/application/modes/symbol_jump.rs
@@ -52,16 +52,21 @@ impl AsStr for Symbol {
 }
 
 impl SymbolJumpMode {
-    pub fn new(tokens: &TokenSet, config: SearchSelectConfig) -> Result<SymbolJumpMode> {
-        let symbols = symbols(tokens.iter().chain_err(|| BUFFER_PARSE_FAILED)?);
-
+    pub fn new(config: SearchSelectConfig) -> Result<SymbolJumpMode> {
         Ok(SymbolJumpMode {
             insert: true,
             input: String::new(),
-            symbols,
+            symbols: Vec::new(),
             results: SelectableVec::new(Vec::new()),
             config,
         })
+    }
+
+    pub fn reset(&mut self, tokens: &TokenSet, config: SearchSelectConfig) -> Result<()> {
+        self.symbols = symbols(tokens.iter().chain_err(|| BUFFER_PARSE_FAILED)?);
+        self.config = config;
+
+        Ok(())
     }
 }
 

--- a/src/models/application/modes/syntax.rs
+++ b/src/models/application/modes/syntax.rs
@@ -13,14 +13,19 @@ pub struct SyntaxMode {
 }
 
 impl SyntaxMode {
-    pub fn new(syntaxes: Vec<String>, config: SearchSelectConfig) -> SyntaxMode {
+    pub fn new(config: SearchSelectConfig) -> SyntaxMode {
         SyntaxMode {
             insert: true,
             input: String::new(),
-            syntaxes,
+            syntaxes: Vec::new(),
             results: SelectableVec::new(Vec::new()),
             config,
         }
+    }
+
+    pub fn reset(&mut self, syntaxes: Vec<String>, config: SearchSelectConfig) {
+        self.syntaxes = syntaxes;
+        self.config = config;
     }
 }
 

--- a/src/models/application/modes/theme.rs
+++ b/src/models/application/modes/theme.rs
@@ -4,6 +4,7 @@ use fragment;
 use std::fmt;
 use std::slice::Iter;
 
+#[derive(Default)]
 pub struct ThemeMode {
     insert: bool,
     input: String,
@@ -15,17 +16,19 @@ pub struct ThemeMode {
 impl ThemeMode {
     pub fn new(config: SearchSelectConfig) -> ThemeMode {
         ThemeMode {
-            insert: true,
-            input: String::new(),
-            themes: Vec::new(),
-            results: SelectableVec::new(Vec::new()),
             config,
+            insert: true,
+            ..Default::default()
         }
     }
 
     pub fn reset(&mut self, themes: Vec<String>, config: SearchSelectConfig) {
-        self.themes = themes;
-        self.config = config;
+        *self = ThemeMode {
+            config,
+            insert: true,
+            themes,
+            ..Default::default()
+        };
     }
 }
 

--- a/src/models/application/modes/theme.rs
+++ b/src/models/application/modes/theme.rs
@@ -13,14 +13,19 @@ pub struct ThemeMode {
 }
 
 impl ThemeMode {
-    pub fn new(themes: Vec<String>, config: SearchSelectConfig) -> ThemeMode {
+    pub fn new(config: SearchSelectConfig) -> ThemeMode {
         ThemeMode {
             insert: true,
             input: String::new(),
-            themes,
+            themes: Vec::new(),
             results: SelectableVec::new(Vec::new()),
             config,
         }
+    }
+
+    pub fn reset(&mut self, themes: Vec<String>, config: SearchSelectConfig) {
+        self.themes = themes;
+        self.config = config;
     }
 }
 

--- a/src/util/selectable_vec.rs
+++ b/src/util/selectable_vec.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 /// A simple decorator around a Vec that allows a single element to be selected.
 /// The selection can be incremented/decremented in single steps, and the
 /// selected value wraps when moved beyond either edge of the set.
+#[derive(Default)]
 pub struct SelectableVec<T> {
     set: Vec<T>,
     selected_index: usize,


### PR DESCRIPTION
As of today, Amp tracks its current/active mode using a single `enum` field on the `Application` type. When the active mode is changed, the old mode is discarded and a new one is constructed. A side effect of this is that the active mode's state is lost during the transition. There are situations where persisting and recalling state across modes is beneficial:

* when searching/replacing text, preserving the search query so you can quickly find the next match after making edits
* when selecting a range of text in `Select`/`SelectLine` modes, temporarily switching to jump mode to select the end of the range
* pinning search tokens in open mode to narrow down results to your area of focus when working in larger projects

The first two behaviors above exist today, but as you'll see in the diff below, they're implemented by explicitly storing required state in their relevant modes or the `Application` type itself. This has helped minimize and isolate the complexity involved with persistent state, but as we look to implement more features that require it, the pattern justifies building a generalized system that handles this for _all_ use cases.

That generalized system is the focus of this PR. As you'll see below, we now build all application modes up front, store them in a hash map, and recall them when switching modes. To do so, I needed to introduce the following notable changes:

* build all modes when initializing the `Application` type to hydrate the map
* add a new `ModeKey` type as a stateless `enum` key into the map
* add a `reset` method to modes where a clean slate is expected (e.g. rebuilding open mode's project directory index)

Once this lands, we'll be able to leverage these persistent modes to build some neat features that should really help improve the ergonomics of Amp. 😎 