### PR TITLE
Remove lint workflow job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,11 +18,3 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: rustfmt
-      run: rustfmt --check src/**/*.rs
-    - name: clippy
-      run: cargo clippy -- -D warnings


### PR DESCRIPTION
Until we can filter these to the just the changes in a PR, these are an annoyance. This is wouldn't be so bad if the lints didn't change over time, but because they do, running the job against the entire codebase introduces new issues unrelated to the PR, even if it was previously compliant.